### PR TITLE
Fix/remove plugins action

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -1,16 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE structures SYSTEM "../../tao/doc/structures.dtd">
 <structures>
-    <structure id="delivery" name="Deliveries" level="4" group="main">
-        <description />
-        <sections>
-            <section id="manage_delivery_assembly" name="Deliveries" url="/taoDeliveryRdf/DeliveryMgmt/index">
-                <actions>
-                    <action id="delivery-plugins" name="Plugins" url="/taoTestRunnerPlugins/Delivery/index" group="tree" context="resource">
-                        <icon id="icon-extension"/>
-                    </action>
-                </actions>
-            </section>
-        </sections>
-    </structure>
 </structures>

--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '0.3.1',
+    'version' => '0.3.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=8.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -34,6 +34,6 @@ class Updater extends common_ext_ExtensionUpdater
      */
     public function update($initialVersion)
     {
-        $this->skip('0.1.0', '0.3.1');
+        $this->skip('0.1.0', '0.3.2');
     }
 }


### PR DESCRIPTION
At the beginning this extension was there to add a GUI to the plugin registry. If you look into the Delivery extension, below the tree there's a "Plugins" action. I've remove the action since it's only a placeholder...