### PR TITLE
Fix/tao 5126 interrupt render item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '1.5.1',
+    'version' => '1.5.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -138,6 +138,6 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('1.5.0');
         }
-        $this->skip('1.5.0', '1.5.1');
+        $this->skip('1.5.0', '1.5.2');
     }
 }

--- a/views/js/runner/plugins/security/sectionPause.js
+++ b/views/js/runner/plugins/security/sectionPause.js
@@ -24,9 +24,10 @@
 define([
     'lodash',
     'i18n',
+    'core/promise',
     'taoTests/runner/plugin',
     'taoQtiTest/runner/helpers/map'
-], function(_, __, pluginFactory, mapHelper) {
+], function(_, __, Promise, pluginFactory, mapHelper) {
     'use strict';
 
     var pauseMessage = __('All students will begin the next section at the same time. Please relax quietly until the room supervisor starts the next section.');
@@ -48,19 +49,23 @@ define([
                 var map     = testRunner.getTestMap();
                 var section = mapHelper.getSection(map, context.sectionId);
 
-                if (prevSection && section && prevSection.id !== section.id && context.sectionPause) {
-                    testRunner.getAreaBroker().getContainer().hide();
-                    testRunner
-                        .trigger('beforesectionpause')
-                        .trigger('pause', {
-                            reasons : {
-                                category : __('condition'),
-                                subCategory : __('pausedSection')
-                            },
-                            message: pauseMessage
-                        });
-                }
-                prevSection = section;
+                return new Promise(function(resolve, reject){
+                    if (prevSection && section && prevSection.id !== section.id && context.sectionPause) {
+                        testRunner
+                            .trigger('disableitem')
+                            .trigger('pause', {
+                                reasons : {
+                                    category : __('condition'),
+                                    subCategory : __('pausedSection')
+                                },
+                                message: pauseMessage
+                            });
+                        return reject();
+                    }
+
+                    prevSection = section;
+                    return resolve();
+                } );
             });
         }
     });


### PR DESCRIPTION
Companion PR https://github.com/oat-sa/extension-tao-test/pull/186

Prevent the rendering of the item so the latencies doesn't record a start for an item that doesn't have started. 
Since the sectionPause plugin checks if the _current section_ has the `sectionPause` flag on the `loaditem`, we need to prevent the `renderitem` if the pause occur. The event was triggered with the effect to start the recording of the latencies, even if the test paused (the event had the time to trigger during the pause request, etc.)