### PR TITLE
Fix/tao 5134 bad endsession

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
         'tao' => '>=10.0.0',
         'taoDelivery' =>  '>=7.1.0',
         'taoDeliveryRdf' =>  '>=1.6.0',
-        'taoQtiTest' =>  '>=15.7.4',
+        'taoQtiTest' =>  '>=15.7.3',
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoTestRunnerPluginsManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -22,13 +22,13 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '1.5.2',
+    'version' => '1.6.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.0.0',
         'taoDelivery' =>  '>=7.1.0',
         'taoDeliveryRdf' =>  '>=1.6.0',
-        'taoQtiTest' =>  '>=14.2.0',
+        'taoQtiTest' =>  '>=15.7.4',
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoTestRunnerPluginsManager',
     'acl' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -138,6 +138,6 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('1.5.0');
         }
-        $this->skip('1.5.0', '1.5.2');
+        $this->skip('1.5.0', '1.6.0');
     }
 }

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -166,7 +166,6 @@ define([
                 return sendVariables();
             });
             testRunner.before('exit', function() {
-                testRunner.trigger('endsession');
                 return sendVariables();
             });
         }


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-testqti/pull/1026
The artificial `endsession` on `exit` is not required anymore