### PR TITLE
Feature/tao 5175 answer cache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '1.6.0',
+    'version' => '1.7.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.0.0',

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -34,6 +34,18 @@ use oat\taoTests\models\runner\plugins\TestPlugin;
 class RegisterTestRunnerPlugins extends InstallAction
 {
     public static $plugins = [
+        'content' => [
+            [
+                'id' => 'answerCache',
+                'name' => 'Answers cache',
+                'module' => 'taoTestRunnerPlugins/runner/plugins/content/answerCache',
+                'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
+                'description' => 'Cache the answers to restore them after refresh',
+                'category' => 'content',
+                'active' => false,
+                'tags' => [ ]
+            ]
+        ],
         'probes' => [
             [
                 'id' => 'latencyEvents',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -139,5 +139,22 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.5.0');
         }
         $this->skip('1.5.0', '1.6.0');
+
+        if($this->isVersion('1.6.0')){
+            $registry = PluginRegistry::getRegistry();
+
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'answerCache',
+                'name' => 'Answers cache',
+                'module' => 'taoTestRunnerPlugins/runner/plugins/content/answerCache',
+                'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
+                'description' => 'Cache the answers to restore them after refresh',
+                'category' => 'content',
+                'active' => false,
+                'tags' => [] 
+            ]));
+            
+            $this->setVersion('1.7.0');
+        }
     }
 }

--- a/views/js/runner/plugins/content/answerCache.js
+++ b/views/js/runner/plugins/content/answerCache.js
@@ -66,7 +66,11 @@ define([
                         }
                     })
                     .on('unloaditem', function () {
-                        return self.storage.clear();
+                        // the store should not be cleared after a pause
+                        // otherwise the response won't be restored after resume
+                        if (!testRunner.getState('closedOrSuspended')) {
+                            return self.storage.clear();
+                        }
                     });
             });
         },
@@ -75,7 +79,7 @@ define([
          * Called during the runner's destroy phase
          */
         destroy: function destroy() {
-            if (this.storage) {
+            if (this.storage && !this.getTestRunner().getState('closedOrSuspended')) {
                 return this.storage.removeStore();
             }
         }

--- a/views/js/runner/plugins/content/answerCache.js
+++ b/views/js/runner/plugins/content/answerCache.js
@@ -1,0 +1,83 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Plugin that puts in cache the current item's state upon move.
+ * After a page refresh, the cached state is loaded to restore the previously set state.
+ * However if the item has already been responded no change is made.
+ * The cache is cleared when the item attempt is finished.
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'core/store',
+    'util/namespace',
+    'taoTests/runner/plugin',
+    'taoQtiTest/runner/helpers/currentItem'
+], function (storeFactory, namespaceHelper, pluginFactory, currentItem) {
+    'use strict';
+
+    /**
+     * Returns the configured plugin
+     */
+    return pluginFactory({
+
+        name: 'answerCache',
+
+        /**
+         * Initialize the plugin (called during runner's init)
+         */
+        init: function init() {
+            var self = this;
+            var testRunner = this.getTestRunner();
+
+            return storeFactory(this.getName() + '-' + testRunner.getConfig().serviceCallId).then(function (store) {
+                self.storage = store;
+
+                testRunner
+                    .after('renderitem', function () {
+                        var itemRunner = testRunner.itemRunner;
+                        var testContext = testRunner.getTestContext();
+                        var key = testContext.itemIdentifier;
+
+                        if (itemRunner && !currentItem.isAnswered(testRunner)) {
+                            itemRunner.on('responsechange', function () {
+                                self.storage.setItem(key, itemRunner.getState());
+                            });
+                            return self.storage.getItem(key)
+                                .then(function (state) {
+                                    if (state) {
+                                        itemRunner.setState(state);
+                                    }
+                                });
+                        }
+                    })
+                    .on('unloaditem', function () {
+                        return self.storage.clear();
+                    });
+            });
+        },
+
+        /**
+         * Called during the runner's destroy phase
+         */
+        destroy: function destroy() {
+            if (this.storage) {
+                return this.storage.removeStore();
+            }
+        }
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5175

Plugin that puts in cache the current item's state upon move.
After a page refresh, the cached state is loaded to restore the previously set state.
However if the item has already been responded no change is made (i.e. if the state is loaded from the server, after a move back for instance).
The cache is cleared when the item attempt is finished, and the store is removed at the end of the test.