### PR TITLE
Store item variables before move

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '1.10.0',
+    'version' => '1.10.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -157,6 +157,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.8.0');
         }
 
-        $this->skip('1.8.0', '1.10.0');
+        $this->skip('1.8.0', '1.10.1');
     }
 }

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -144,22 +144,28 @@ define([
              * Send latency data
              */
             function sendVariables() {
-                probeOverseer.flush().then(function(data){
-                    var traceData = {};
-                    //we reformat the time set into a trace variables
-                    if(data && data.length){
-                        _.forEach(data, function(entry){
-                            var id = entry.type + '-' + entry.id;
+                return new Promise(function(resolve, reject){
+                    probeOverseer.flush().then(function(data){
+                        var traceData = {};
+                        //we reformat the time set into a trace variables
+                        if(data && data.length){
+                            _.forEach(data, function(entry){
+                                var id = entry.type + '-' + entry.id;
 
-                            if(entry.marker){
-                                id = entry.marker + '-' + id;
-                            }
-                            traceData[id] = entry;
-                        });
-                        //and send them
-                        return testRunner.getProxy()
-                            .sendVariables(traceData, true);
-                    }
+                                if(entry.marker){
+                                    id = entry.marker + '-' + id;
+                                }
+                                traceData[id] = entry;
+                            });
+                            //and send them
+                            testRunner.getProxy()
+                                .sendVariables(traceData, true);
+
+                        }
+                        resolve(data);
+                    }).catch(function(err){
+                        reject(err);
+                    });
                 });
             }
 

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -144,28 +144,23 @@ define([
              * Send latency data
              */
             function sendVariables() {
-                return new Promise(function(resolve, reject){
-                    probeOverseer.flush().then(function(data){
-                        var traceData = {};
-                        //we reformat the time set into a trace variables
-                        if(data && data.length){
-                            _.forEach(data, function(entry){
-                                var id = entry.type + '-' + entry.id;
+                return probeOverseer.flush().then(function(data){
+                    var traceData = {};
+                    //we reformat the time set into a trace variables
+                    if(data && data.length){
+                        _.forEach(data, function(entry){
+                            var id = entry.type + '-' + entry.id;
 
-                                if(entry.marker){
-                                    id = entry.marker + '-' + id;
-                                }
-                                traceData[id] = entry;
-                            });
-                            //and send them
-                            testRunner.getProxy()
-                                .sendVariables(traceData, true);
-
-                        }
-                        resolve(data);
-                    }).catch(function(err){
-                        reject(err);
-                    });
+                            if(entry.marker){
+                                id = entry.marker + '-' + id;
+                            }
+                            traceData[id] = entry;
+                        });
+                        //and send them
+                        testRunner.getProxy()
+                            .sendVariables(traceData, true);
+                    }
+                    return data;
                 });
             }
 


### PR DESCRIPTION
Sometimes we have missed values in ODS because of on edge case:

1. When on the very last item test taker presses `next` button we send move event to the server.
2. On the server side test runner finishes test session and ODS event listener catch this event and put task into queue.
3. After each move we sent `storeTraceData` which contains client start/end time, timer values and some more data related to the lase seen item. But if task queue picks up this task very fast, this data will be stored after ODS generated (because `storeTraceData` was not processed yet).

Also it occurs each time if `InMemoryQueueBroker` is configured (what means that task in the queue will be executed right after it was created.

latency plugin sends data on `before('unloaditem')` event and move request sends on `on('unloaditem')` event, but collection of latency data takes more time and `storeTraceData` gets into request queue after `move` event. If we return promise in `before` event listener in `latency.js` it will fix this bug.