### PR TITLE
Fix/tao 5774 offline section pause

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '1.10.1',
+    'version' => '1.10.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -157,6 +157,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.8.0');
         }
 
-        $this->skip('1.8.0', '1.10.1');
+        $this->skip('1.8.0', '1.10.2');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5774

Fix the issue occurring when the browser is in offline mode and the test taker enters in a section that has the `x-tao-proctored-auto-pause` option.

The cause of the issue is the following:
- the pause action triggers a request, that fails because of a connectivity issue
- the pause action is put in a waiting state
- when the connection is back, all pending actions are synchronized with the server (so the pause action)
- then the pause action is resumed, and a double pause occurs because the synchronized pause has already been taken into account (the server refuses to pause again the execution, and the runner fails to continue)

The difficulty was to prevent the double pause and to correctly manage the pause with the expected behavior (exit the test with a particular message displayed to the test taker). The pause action tries to send a request and handles the result on its own, but this is not hookable from a plugin: we cannot interfere in this process.

The solution is to prevent the pause to be resumed, and to apply the expected behavior by launching it from the plugin itself.

A test has been added to the ticket to ease to reproduce the issue and to test the patch without having to walk through a boring and huge tutorial section...