### PR TITLE
Fix/tao 5939 compatible timers

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '1.11.0',
+    'version' => '1.11.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=16.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -157,6 +157,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.8.0');
         }
 
-        $this->skip('1.8.0', '1.11.0');
+        $this->skip('1.8.0', '1.11.1');
     }
 }

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -197,7 +197,17 @@ define([
          * @returns {Number|null}
          */
         getTimerValue: function getTimerValue(name) {
-            return typeof timers[name] === 'object' ? parseInt(timers[name].val(), 10) : null;
+            if(typeof timers[name] === 'object'){
+                if(_.isNumber(timers[name].remainingTime)){
+                    return timers[name].remainingTime;
+                }
+
+                //backward compatilbe format for timers
+                if(_.isFunction(timers[name].val)){
+                    return  parseInt(timers[name].val(), 10);
+                }
+            }
+            return null;
         },
 
         /**


### PR DESCRIPTION
I've found a bug with the latency collection, the timers were directly called by the latency plugin. So I need to make the collection backward and forward compatible.

This is related to https://github.com/oat-sa/extension-tao-testqti/pull/1233