### PR TITLE
[TAO-8037] NFER Pages lack main H1 heading 3764NFER-8

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.5.0',
+    'version' => '2.6.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -139,7 +139,19 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'active' => false,
                 'tags' => [ ]
             ]
-        ]
+        ],
+        'accessibility' => [
+            [
+                'id' => 'defaultHeading',
+                'name' => 'Default Heading',
+                'module' => 'taoTestRunnerPlugins/runner/plugins/accessibility/defaultHeading',
+                'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
+                'description' => 'Added h1 tag with default text in case if there is no h1 tags in test item. The tag will be visible only for screenreader devices',
+                'category' => 'accessibility',
+                'active' => false,
+                'tags' => [ ]
+            ]
+        ],
     ];
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -246,5 +246,22 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('2.3.0', '2.5.0');
+
+        if ($this->isVersion('2.5.0')) {
+            $registry = PluginRegistry::getRegistry();
+
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'defaultHeading',
+                'name' => 'Default Heading',
+                'module' => 'taoTestRunnerPlugins/runner/plugins/accessibility/defaultHeading',
+                'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
+                'description' => 'Added h1 tag with default text in case if there is no h1 tags in test item. The tag will be visible only for screenreader devices',
+                'category' => 'accessibility',
+                'active' => false,
+                'tags' => [ ]
+            ]));
+
+            $this->setVersion('2.6.0');
+        }
     }
 }

--- a/views/js/runner/plugins/accessibility/defaultHeading.js
+++ b/views/js/runner/plugins/accessibility/defaultHeading.js
@@ -1,0 +1,90 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Anton Tsymuk <anton@taotesting.com>
+ */
+define([
+    'jquery',
+    'i18n',
+    'taoTests/runner/plugin'
+], function ($, __, pluginFactory) {
+    'use strict';
+
+    var defaultHeadingText = __('Assessment Item');
+    // Styles for heading to make it visible only for screenreader devices
+    var headingCss = {
+        border: 0,
+        clip: 'rect(0 0 0 0)',
+        height: '1px',
+        margin: '-1px',
+        overflow: 'hidden',
+        padding: '0',
+        position: 'absolute',
+        width: '1px',
+    };
+
+    /**
+     * Creates the defaultHeading plugin.
+     * Added h1 tag with default text in case if there is no h1 tags in test item
+     * The tag will be visible only for screenreader devices
+     */
+    return pluginFactory({
+
+        name: 'defaultHeading',
+
+        /**
+         * Initializes the plugin (called during runner's init)
+         */
+        init: function init() {
+            var testRunner = this.getTestRunner();
+            var testData = testRunner.getTestData() || {};
+            var testConfig = testData.config || {};
+            var pluginsConfig = testConfig.plugins || {};
+            var config = pluginsConfig.defaultHeading || {};
+            var headingText = config.heading || defaultHeadingText;
+            var headingTag;
+
+            // Add if necessary default h1 tag after every item render
+            testRunner
+                .on('renderitem', function () {
+                    var headingTagsCount = $('.content-wrap h1').length;
+
+                    if (headingTagsCount) {
+                        if (headingTag) {
+                            headingTag.remove();
+                            headingTag = undefined;
+                        }
+
+                        return;
+                    } else if (headingTag) {
+                        return;
+                    }
+
+                    headingTag = $('<h1>' + headingText + '</h1>')
+                        .css(headingCss)
+                        .attr('id', 'defaultHeading');
+
+                    $('body').prepend(headingTag);
+                });
+        },
+
+        destroy: function () {
+            $('#defaultHeading').remove();
+        }
+    });
+});

--- a/views/js/runner/plugins/accessibility/defaultHeading.js
+++ b/views/js/runner/plugins/accessibility/defaultHeading.js
@@ -40,7 +40,7 @@ define([
 
     /**
      * Creates the defaultHeading plugin.
-     * Added h1 tag with default text in case if there is no h1 tags in test item
+     * Add h1 tag with default text in case if there is no h1 tags in test item
      * The tag will be visible only for screenreader devices
      */
     return pluginFactory({

--- a/views/js/test/runner/plugins/accessibility/defaultHeading/test.html
+++ b/views/js/test/runner/plugins/accessibility/defaultHeading/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner Plugins - Default Heading</title>
+        <base href="../../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="latency.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoTestRunnerPlugins/test/runner/plugins/accessibility/defaultHeading/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/plugins/accessibility/defaultHeading/test.js
+++ b/views/js/test/runner/plugins/accessibility/defaultHeading/test.js
@@ -1,0 +1,104 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Anton Tsymuk <anton@taotesting.com>
+ */
+
+define([
+    'jquery',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoTestRunnerPlugins/runner/plugins/accessibility/defaultHeading'
+], function ($, runnerFactory, providerMock, pluginFactory) {
+    'use strict';
+
+    var pluginApi;
+    var providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    QUnit.module('defaultHeading', {
+        beforeEach: function () {
+            $('#qunit-fixture').empty();
+        }
+    });
+
+    QUnit.test('module', function (assert) {
+        var runner = runnerFactory(providerName);
+
+        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(pluginFactory(runner), pluginFactory(runner), 'The plugin factory provides a different instance on each call');
+    });
+
+    pluginApi = [
+        {
+            name: 'init',
+            title: 'init'
+        },
+        {
+            name: 'destroy',
+            title: 'destroy'
+        }
+    ];
+
+    QUnit
+        .cases.init(pluginApi)
+        .test('plugin API ', function (data, assert) {
+            var runner = runnerFactory(providerName);
+            var plugin = pluginFactory(runner);
+
+            assert.equal(typeof plugin[data.name], 'function', 'The pluginFactory instances expose a "' + data.name + '" function');
+        });
+
+    QUnit.test('init', function (assert) {
+        var runner = runnerFactory(providerName);
+        var plugin = pluginFactory(runner);
+
+        plugin.init();
+
+        assert.equal($('.content-wrap h1').length, 0, 'There is no h1 tags');
+
+        runner.trigger('renderitem');
+
+        assert.equal($('#defaultHeading').length, 1, 'Default heading tag has been added');
+
+        $('#qunit-fixture').html('<div class="content-wrap"><h1>test</h1></div>');
+
+        runner.trigger('renderitem');
+
+        assert.equal($('#defaultHeading').length, 0, 'Default heading tag has been removed');
+    });
+
+    QUnit.test('destroy', function (assert) {
+        var runner = runnerFactory(providerName);
+        var plugin = pluginFactory(runner);
+
+        plugin.init();
+
+        runner.trigger('renderitem');
+
+        $('#qunit-fixture').html('<div class="content-wrap"><h1>test</h1></div>');
+        assert.equal(true, true);
+
+        assert.equal($('#defaultHeading').length, 1, 'Default heading tag has been added');
+
+        plugin.destroy();
+
+        assert.equal($('#defaultHeading').length, 0, 'Default heading tag has been removed');
+    });
+});

--- a/views/js/test/runner/plugins/accessibility/defaultHeading/test.js
+++ b/views/js/test/runner/plugins/accessibility/defaultHeading/test.js
@@ -38,6 +38,8 @@ define([
     });
 
     QUnit.test('module', function (assert) {
+        assert.expect(3);
+
         var runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
@@ -59,6 +61,8 @@ define([
     QUnit
         .cases.init(pluginApi)
         .test('plugin API ', function (data, assert) {
+            assert.expect(1);
+
             var runner = runnerFactory(providerName);
             var plugin = pluginFactory(runner);
 
@@ -66,6 +70,8 @@ define([
         });
 
     QUnit.test('init', function (assert) {
+        assert.expect(3);
+
         var runner = runnerFactory(providerName);
         var plugin = pluginFactory(runner);
 
@@ -85,6 +91,8 @@ define([
     });
 
     QUnit.test('destroy', function (assert) {
+        assert.expect(3);
+
         var runner = runnerFactory(providerName);
         var plugin = pluginFactory(runner);
 


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8037
 
Creates the defaultHeading plugin. 
The plugin adds h1 tag with default text in case if there is no h1 tags in test item. The tag will be visible only for screenreader devices
  
#### How to test
 
1. Enable defaultHeading plugin
2. Run delivery with items without h1 tag
3. Check if h1 tags is added
 
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-nfer/pull/120