### PR TITLE
[TAO-8123] WK-1308 Clicking on scratchpad pauses the assessment.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.7.0',
+    'version' => '2.7.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.7.0');
+        $this->skip('2.6.0', '2.7.1');
     }
 }

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -113,12 +113,14 @@ define([
 
             var handleInnerWindowFocusLoose = function handleInnerWindowFocusLoose(){
                 innerFocus = false;
-                _.defer(function(){
+                // select element on iOS devices for some reason lost focus when an option is selected
+                // but after some delay the focus is restored back to the element
+                _.delay(function(){
                     if(!mainFocus && !innerFocus){
                         //the inner window has lost the focus and no one else has it
                         doPause();
                     }
-                });
+                }, focusBackTimeoutDelayMs);
             };
 
             var handleIframesFocus = function handleIframesFocus(){


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8123
 
During delivery execution in security mode, if user try to change font or font size while using scratchpad tool, the test will be paused
 
#### Steps to reproduce  (for bugs)
 - Prepare a delivery whit enabled scratchpad tool and security mode 
 - Run the delivery on an iOS device and activate the scratchpad tool
 - Try to change font or font size
  