### PR TITLE
[TAO-7930] WK-1286 PG - TCiaB - extended text interaction enhancement for touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.7.1',
+    'version' => '2.7.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.7.1');
+        $this->skip('2.6.0', '2.7.2');
     }
 }

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -61,6 +61,7 @@ define([
             // Fix for TAO-4419 (Edge compatibility)
             // We slightly delay the actual blur to give the focus a chance to come back very quickly.
             // This allow the test taker to close the annoying full screen confirmation message displayed by Edge.
+            // Also this handle the case when there is a delay while focus moved to ckeditor
             var focusBackTimeoutDelayMs = 200;
             var focusBackTimeout = function focusBackTimeout() {
                 return new Promise(function(resolve, reject) {
@@ -70,7 +71,10 @@ define([
                     });
                     _.delay(function() {
                         pageStatus.off('.focusBack');
-                        resolve(); // focus is lost for good
+
+                        // check that the inner focus is not back as well
+                        innerFocus ? reject() : resolve();
+
                     }, focusBackTimeoutDelayMs);
                 });
             };


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-7930
 
On iOS devices during delivery execution with extended text interaction, when you try to use extended text interaction the focus is lost from the page and the delivery execution is paused. The problem is that ckeditor handle focus event and there is a delay before the focus event fired from it 
  
#### How to test

- Prepare the delivery with an item which contains extended text interaction and secure mode enabled
- Run test and try to use extended text interaction
- Check the that delivery execution not paused
 