### PR TITLE
[TAO-7929] WK-1287 PG - TCiaB - simple text interaction enhancement for touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.8.0',
+    'version' => '2.8.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.8.0');
+        $this->skip('2.6.0', '2.8.1');
     }
 }

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -179,6 +179,7 @@ define([
                 .on('renderitem', handleIframesFocus)
                 .on('unloaditem', function(){
                     innerFocus = false;
+                    ckEditorFocus = false;
                 });
         }
     });

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -119,6 +119,8 @@ define([
                 }
             };
 
+            var handleCkEditorFocus = handleInnerWindowFocus.bind(null, null, true);
+
             var handleInnerWindowFocusLoose = function handleInnerWindowFocusLoose(e, ckEditor){
                 if (ckEditor) {
                     ckEditorFocus = false;
@@ -133,6 +135,8 @@ define([
                 });
             };
 
+            var handleCkEditorFocusLoose = handleInnerWindowFocusLoose.bind(null, null, true);
+
             var handleIframesFocus = function handleIframesFocus(){
 
                 //all iframe that could be within the item
@@ -142,9 +146,9 @@ define([
                             var instanceIdentifier = this.title.substr(this.title.indexOf('editor'));
                             var editor = window.CKEDITOR.instances[instanceIdentifier];
 
-                            editor.on('focus', function() { handleInnerWindowFocus(null, true); });
+                            editor.on('focus', handleCkEditorFocus);
 
-                            editor.on('blur', function() { handleInnerWindowFocusLoose(null, true); });
+                            editor.on('blur', handleCkEditorFocusLoose);
                         }
 
                         this.contentWindow.addEventListener('focus', handleInnerWindowFocus);

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -111,29 +111,20 @@ define([
                 return elt.className.indexOf('cke_') !== -1;
             };
 
-            //moved iframe handle functions (next 2) from inline, just to avoid code duplication
-            var handleInnerWindowFocus = function handleInnerWindowFocus(){
-                innerFocus = true;
+            var handleCkEditorFocus = function handleInnerWindowFocus(e, ckEditor){
+                if (ckEditor) {
+                    ckEditorFocus = true;
+                } else {
+                    innerFocus = true;
+                }
             };
 
-            var handleInnerWindowFocusLoose = function handleInnerWindowFocusLoose(){
-                innerFocus = false;
-                // select element on iOS devices for some reason lost focus when an option is selected
-                // but after some delay the focus is restored back to the element
-                _.delay(function(){
-                    if(!mainFocus && !innerFocus && !ckEditorFocus){
-                        //the inner window has lost the focus and no one else has it
-                        doPause();
-                    }
-                }, focusBackTimeoutDelayMs);
-            };
-
-            var handleCkEditorFocus = function handleCkEditorFocus(){
-                ckEditorFocus = true;
-            };
-
-            var handleCkEditorFocusLoose = function handleCkEditorFocusLoose(){
-                ckEditorFocus = false;
+            var handleCkEditorFocusLoose = function handleInnerWindowFocusLoose(e, ckEditor){
+                if (ckEditor) {
+                    ckEditorFocus = false;
+                } else {
+                    innerFocus = false;
+                }
 
                 _.defer(function(){
                     if(!mainFocus && !innerFocus && !ckEditorFocus){
@@ -151,9 +142,9 @@ define([
                             var instanceIdentifier = this.title.substr(this.title.indexOf('editor'));
                             var editor = window.CKEDITOR.instances[instanceIdentifier];
 
-                            editor.on('focus', handleCkEditorFocus);
+                            editor.on('focus', () => handleInnerWindowFocus(null, true));
 
-                            editor.on('blur', handleCkEditorFocusLoose);
+                            editor.on('blur', () => handleInnerWindowFocusLoose(null, true));
                         }
 
                         this.contentWindow.addEventListener('focus', handleInnerWindowFocus);

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -111,7 +111,7 @@ define([
                 return elt.className.indexOf('cke_') !== -1;
             };
 
-            var handleCkEditorFocus = function handleInnerWindowFocus(e, ckEditor){
+            var handleInnerWindowFocus = function handleInnerWindowFocus(e, ckEditor){
                 if (ckEditor) {
                     ckEditorFocus = true;
                 } else {
@@ -119,7 +119,7 @@ define([
                 }
             };
 
-            var handleCkEditorFocusLoose = function handleInnerWindowFocusLoose(e, ckEditor){
+            var handleInnerWindowFocusLoose = function handleInnerWindowFocusLoose(e, ckEditor){
                 if (ckEditor) {
                     ckEditorFocus = false;
                 } else {

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -142,9 +142,9 @@ define([
                             var instanceIdentifier = this.title.substr(this.title.indexOf('editor'));
                             var editor = window.CKEDITOR.instances[instanceIdentifier];
 
-                            editor.on('focus', () => handleInnerWindowFocus(null, true));
+                            editor.on('focus', function() { handleInnerWindowFocus(null, true); });
 
-                            editor.on('blur', () => handleInnerWindowFocusLoose(null, true));
+                            editor.on('blur', function() { handleInnerWindowFocusLoose(null, true); });
                         }
 
                         this.contentWindow.addEventListener('focus', handleInnerWindowFocus);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-7929?oldIssueView=true
 
During usage of extended text interaction of type XHTML if the keyboard is hidden using keyboard's control the ckEditor is blur and iframe which wraps ckEditor focused, so to prevent assessment pausing because of focus lose, ckEditor iframe focus should be additionally handled 
  
#### How to test
 
- Prepare a delivery with extended text interaction of type XHTML
- Run the delivery as a test taker on iOS device
- Tty to type some text and after that hide the keyboard using keyboard control
- Check that assessment is not paused

Additionally you can a video in the ticket with process how to reproduce the issue