### PR TITLE
Deprecate test data

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,14 +22,14 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.8.2',
+    'version' => '2.9.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',
         'taoDelivery'    => '>=11.0.0',
         'taoDeliveryRdf' => '>=6.0.0',
-        'taoQtiTest'     => '>=29.0.0',
-        'taoTests'       => '>=8.0.0',
+        'taoQtiTest'     => '>=34.5.0',
+        'taoTests'       => '>=13.3.0',
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoTestRunnerPluginsManager',
     'acl' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.8.2');
+        $this->skip('2.6.0', '2.9.0');
     }
 }

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -32,6 +32,7 @@ module.exports = function(grunt) {
                     dependencies : ['taoQtiTest', 'taoTests'],
                     bundles : [{
                         name : 'testPlugins',
+                        babel : true,
                         include: ['taoTestRunnerPlugins/runner/plugins/**/*'],
                         dependencies : []
                     }]

--- a/views/js/runner/plugins/accessibility/defaultHeading.js
+++ b/views/js/runner/plugins/accessibility/defaultHeading.js
@@ -51,13 +51,10 @@ define([
          * Initializes the plugin (called during runner's init)
          */
         init: function init() {
-            var testRunner = this.getTestRunner();
-            var testData = testRunner.getTestData() || {};
-            var testConfig = testData.config || {};
-            var pluginsConfig = testConfig.plugins || {};
-            var config = pluginsConfig.defaultHeading || {};
-            var headingText = config.heading || defaultHeadingText;
-            var headingTag;
+            const testRunner = this.getTestRunner();
+            const config = this.getConfig();
+            const headingText = config.heading || defaultHeadingText;
+            let headingTag;
 
             // Add if necessary default h1 tag after every item render
             testRunner

--- a/views/js/runner/plugins/connectivity/disconnectedTestSaver.js
+++ b/views/js/runner/plugins/connectivity/disconnectedTestSaver.js
@@ -233,19 +233,22 @@ define([
              * @returns {Promise}
              */
             this.prepareDownload = function prepareDownload(actions) {
-                var trConfig = testRunner.getConfig();
-                var timestamp = Date.now();
-                var dateTime = new Date(timestamp).toISOString();
-                var testData = testRunner.getTestData();
-                var testId = testData.title;
-                var niceFilename = 'Download of ' + testId + ' at ' + dateTime + '.json';
+                const testConfig = testRunner.getConfig();
+                const timestamp = Date.now();
+                const dateTime = new Date(timestamp).toISOString();
+
+                //@deprecated  this can be empty, all values will be available from the config
+                const testData = testRunner.getTestData() || {};
+                const testMap  = testRunner.getTestMap();
+                const testTitle = testMap.title || testData.title;
+                const filename = `Download of ${testTitle} at ${dateTime}.json`;
 
                 return {
-                    filename: niceFilename,
+                    filename,
                     content: JSON.stringify({
-                        timestamp: timestamp,
-                        testData: testData,
-                        testConfig: trConfig,
+                        timestamp,
+                        testData,
+                        testConfig,
                         actionQueue: actions
                     })
                 };

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -92,9 +92,9 @@ define([
          * @returns {Object}
          */
         captureTest: function captureTest(testRunner){
-            var data = testRunner.getTestData();
+            const testMap = testRunner.getTestMap();
             return {
-                testId : data.identifier
+                testId : testMap.identifier
             };
         },
 
@@ -104,10 +104,10 @@ define([
          * @returns {Object}
          */
         captureAll: function captureAll(testRunner){
-            var data = testRunner.getTestData();
-            var context = testRunner.getTestContext();
+            const context = testRunner.getTestContext();
+            const testMap = testRunner.getTestMap();
             return {
-                testId : data.identifier,
+                testId : testMap.identifier,
                 testPartId : context.testPartId,
                 sectionId : context.sectionId,
                 itemId : context.itemIdentifier,

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -25,8 +25,9 @@ define([
     'lodash',
     'i18n',
     'ui/pageStatus',
-    'taoTests/runner/plugin'
-], function (_, __, pageStatusFactory, pluginFactory) {
+    'taoTests/runner/plugin',
+    'taoQtiTest/runner/config/states'
+], function (_, __, pageStatusFactory, pluginFactory, states) {
     'use strict';
 
     var pageStatus = pageStatusFactory();
@@ -82,8 +83,7 @@ define([
 
             var doPause = function doPause() {
                 var context = testRunner.getTestContext();
-                var states = testRunner.getTestData().states;
-                if (!bluring && context.state <= states.interacting && !testRunner.getState('finish')) {
+                if (!bluring && context.state <= states.testSessionStates.interacting && !testRunner.getState('finish')) {
                     bluring = true;
                     focusBackTimeout()
                         .then(function resolve() {

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -22,8 +22,9 @@
 define([
     'lodash',
     'i18n',
-    'taoTests/runner/plugin'
-], function (_, __, pluginFactory) {
+    'taoTests/runner/plugin',
+    'taoQtiTest/runner/config/states'
+], function (_, __, pluginFactory, states) {
     'use strict';
 
     var doc = document;
@@ -269,8 +270,7 @@ define([
 
             function doPause() {
                 var context = testRunner.getTestContext();
-                var states = testRunner.getTestData().states;
-                if (context.state <= states.interacting && !testRunner.getState('finish')) {
+                if (context.state <= states.testSessionStates.interacting && !testRunner.getState('finish')) {
                     testRunner.trigger('pause', {reason: launchError});
                 }
             }

--- a/views/js/runner/plugins/security/sectionPause.js
+++ b/views/js/runner/plugins/security/sectionPause.js
@@ -24,11 +24,10 @@
 define([
     'lodash',
     'i18n',
-    'core/promise',
     'taoTests/runner/plugin',
     'taoQtiTest/runner/helpers/map',
     'taoQtiTest/runner/config/states'
-], function(_, __, Promise, pluginFactory, mapHelper, states) {
+], function(_, __, pluginFactory, mapHelper, states) {
     'use strict';
 
     /**

--- a/views/js/runner/plugins/security/sectionPause.js
+++ b/views/js/runner/plugins/security/sectionPause.js
@@ -26,8 +26,9 @@ define([
     'i18n',
     'core/promise',
     'taoTests/runner/plugin',
-    'taoQtiTest/runner/helpers/map'
-], function(_, __, Promise, pluginFactory, mapHelper) {
+    'taoQtiTest/runner/helpers/map',
+    'taoQtiTest/runner/config/states'
+], function(_, __, Promise, pluginFactory, mapHelper, states) {
     'use strict';
 
     /**
@@ -78,7 +79,7 @@ define([
                                         .off('.sectionPause')
                                         .before('pause.sectionPause', function() {
                                             testRunner.trigger('leave', {
-                                                code: testRunner.getTestData().states.suspended,
+                                                code: states.testSessionStates.suspended,
                                                 message: pauseMessage
                                             });
                                             return Promise.reject();

--- a/views/js/test/runner/plugins/accessibility/defaultHeading/test.html
+++ b/views/js/test/runner/plugins/accessibility/defaultHeading/test.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="latency.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="defaultHeading.js"></script>
 
         <script  type="text/javascript">
 

--- a/views/js/test/runner/plugins/accessibility/defaultHeading/test.js
+++ b/views/js/test/runner/plugins/accessibility/defaultHeading/test.js
@@ -22,14 +22,18 @@
 define([
     'jquery',
     'taoTests/runner/runner',
-    'taoQtiTest/test/runner/mocks/providerMock',
     'taoTestRunnerPlugins/runner/plugins/accessibility/defaultHeading'
-], function ($, runnerFactory, providerMock, pluginFactory) {
+], function ($, runnerFactory, pluginFactory) {
     'use strict';
 
     var pluginApi;
     var providerName = 'mock';
-    runnerFactory.registerProvider(providerName, providerMock());
+    runnerFactory.registerProvider(providerName, {
+        name: providerName,
+        loadAreaBroker(){ },
+        loadProxy(){ },
+        init(){ }
+    });
 
     QUnit.module('defaultHeading', {
         beforeEach: function () {

--- a/views/js/test/runner/plugins/navigation/limitBackButton/test.js
+++ b/views/js/test/runner/plugins/navigation/limitBackButton/test.js
@@ -20,17 +20,19 @@
  */
 
 define([
-
-    'jquery',
     'taoTests/runner/runner',
-    'taoQtiTest/test/runner/mocks/providerMock',
     'taoTestRunnerPlugins/runner/plugins/navigation/limitBackButton'
-], function($, runnerFactory, providerMock, pluginFactory) {
+], function(runnerFactory, pluginFactory) {
     'use strict';
 
     var pluginApi;
     var providerName = 'mock';
-    runnerFactory.registerProvider(providerName, providerMock());
+    runnerFactory.registerProvider(providerName, {
+        name: providerName,
+        loadAreaBroker(){ },
+        loadProxy(){ },
+        init(){ }
+    });
 
     /**
      * The following tests applies to all plugins

--- a/views/js/test/runner/plugins/probes/latency/test.js
+++ b/views/js/test/runner/plugins/probes/latency/test.js
@@ -19,7 +19,6 @@
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 define([
-
     'lodash',
     'core/eventifier',
     'core/promise',
@@ -70,7 +69,7 @@ define([
         }];
         var idx = 1;
         var probeData = [];
-        var testData = {
+        var testMap = {
             identifier: 'fooBar'
         };
         var testContext = {
@@ -85,7 +84,7 @@ define([
                 type: 'init',
                 marker: null,
                 context: {
-                    testId: testData.identifier
+                    testId: testMap.identifier
                 }
             },
             shortcut: {
@@ -93,7 +92,7 @@ define([
                 type: 'shortcut',
                 marker: null,
                 context: {
-                    testId: testData.identifier,
+                    testId: testMap.identifier,
                     testPartId: testContext.testPartId,
                     sectionId: testContext.sectionId,
                     itemId: testContext.itemIdentifier,
@@ -107,7 +106,7 @@ define([
                 type: 'item',
                 marker: 'stop',
                 context: {
-                    testId: testData.identifier,
+                    testId: testMap.identifier,
                     testPartId: testContext.testPartId,
                     sectionId: testContext.sectionId,
                     itemId: testContext.itemIdentifier,
@@ -137,8 +136,8 @@ define([
                     }
                 };
             },
-            getTestData: function() {
-                return testData;
+            getTestMap() {
+                return testMap;
             },
             getTestContext: function() {
                 return testContext;
@@ -233,8 +232,8 @@ define([
                     sendVariables: function() {}
                 };
             },
-            getTestData: function() {
-                return testData;
+            getTestMap() {
+                return testMap;
             },
             getTestContext: function() {
                 return testContext;


### PR DESCRIPTION
 Related to https://oat-sa.atlassian.net/browse/NEX-238

 -  Use new options methods instead of the deprecated `testData` to ease the future migration

How to test : 
 - Try launching the test runner

Requires :
 - [x] https://github.com/oat-sa/tao-test-runner-fe/pull/12
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/19
 - [x] https://github.com/oat-sa/extension-tao-test/pull/300
 - [x] https://github.com/oat-sa/extension-tao-testqti/pull/1572

