### PR TITLE
Feature/nex 240 deprecate secure pause state required from textcontext

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.9.0',
+    'version' => '2.10.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.9.0');
+        $this->skip('2.6.0', '2.10.0');
     }
 }

--- a/views/js/runner/plugins/security/blurPause.js
+++ b/views/js/runner/plugins/security/blurPause.js
@@ -82,12 +82,13 @@ define([
             };
 
             var doPause = function doPause() {
-                var context = testRunner.getTestContext();
+                const context = testRunner.getTestContext();
+                const options = testRunner.getOptions();
                 if (!bluring && context.state <= states.testSessionStates.interacting && !testRunner.getState('finish')) {
                     bluring = true;
                     focusBackTimeout()
                         .then(function resolve() {
-                            if (context.securePauseStateRequired) {
+                            if (options.securePauseStateRequired) {
                                 testRunner.trigger('blur').trigger('pause', {
                                     message: lostFocusPauseMessage,
                                     reasons : {

--- a/views/js/runner/plugins/security/preventScreenshot.js
+++ b/views/js/runner/plugins/security/preventScreenshot.js
@@ -115,13 +115,12 @@ define([
 
                 $(window)
                 .on('keyup' + '.' + this.getName(), function (e) {
-                    var context;
                     if (e.key === 'PrintScreen') {
                         triggerCopyEvent();
-                        context = testRunner.getTestContext();
+                        const options = testRunner.getOptions();
                         testRunner
                             .trigger('prohibited-key', 'PrintScreen');
-                        if (context.securePauseStateRequired) {
+                        if (options.securePauseStateRequired) {
                             testRunner.trigger('pause', {
                                     message: printScreenPauseMessage,
                                     reasons: {


### PR DESCRIPTION
Deprecate `securePauseStateRequired` from `testContext` and use it from `configuration`.

Do not merge until the decision is made for mentioned question here: https://oat-sa.atlassian.net/wiki/spaces/~18022273/pages/114950566/Test+context+key+deprecations