### PR TITLE
Fix/ncsup 25/fullscreen enablenav

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.10.0',
+    'version' => '2.10.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.10.0');
+        $this->skip('2.6.0', '2.10.1');
     }
 }

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -233,7 +233,7 @@ define([
             }
 
             function enableItem() {
-                if (testRunner.itemRunner !== undefined) {
+                if (testRunner.itemRunner) {
                     testRunner.trigger('enablenav enabletools');
                 }
             }

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -233,7 +233,9 @@ define([
             }
 
             function enableItem() {
-                testRunner.trigger('enablenav enabletools');
+                if (testRunner.itemRunner !== undefined) {
+                    testRunner.trigger('enablenav enabletools');
+                }
             }
 
             function disableItem() {


### PR DESCRIPTION
related issue: https://oat-sa.atlassian.net/browse/NFERSUP-25
Test runner navigation enables right after enter into full screen mode even if item is not loaded.

Steps to reproduce:
1. run test
2. go to the second item
3. refresh the page and while it is loading click on next button very fast. Button should be pressed before item loaded.
4. Select response and press next button after item loaded.

