### PR TITLE
fix lost focus on module button

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.10.1',
+    'version' => '2.10.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.10.1');
+        $this->skip('2.6.0', '2.10.2');
     }
 }

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -321,13 +321,20 @@ define([
                 // listen either to the native or the change event created in the observer above
                 doc.addEventListener(fullScreenEventName, handleFullScreenChange);
 
-                isFullScreen = checkFullScreen();
-                if (!isFullScreen) {
-                    leaveFullScreen(testRunner);
-                    alertUser();
-                } else if (!fullScreenSupported) {
-                    startFullScreenChangeObserver();
-                }
+                // first check should be done after 'renderitem' event
+                // because current focused element will be blured, to reinitialize keyboard navigation
+                // in testRunner in function initTestRunnerNavigation of keyNavigation
+                testRunner.after('renderitem.fullscreen', function() {
+                    isFullScreen = checkFullScreen();
+                    if (!isFullScreen) {
+                        leaveFullScreen(testRunner);
+                        alertUser();
+                    } else if (!fullScreenSupported) {
+                        startFullScreenChangeObserver();
+                    }
+                    testRunner.off('renderitem.fullscreen');
+                })
+                
             } else {
                 this.disable();
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8786

The first check of fullscreen mode was moved to the listener of `renderitem` event of testRunner, because `function initTestRunnerNavigation` will blur the current focused element, to reinitialize keyboard navigation
https://github.com/oat-sa/tao-test-runner-qti-fe/blob/6374eaade4667400b77027218bb63aa302de157e/src/plugins/content/accessibility/keyNavigation.js#L645-L648
https://github.com/oat-sa/tao-test-runner-qti-fe/blob/6374eaade4667400b77027218bb63aa302de157e/src/plugins/content/accessibility/keyNavigation.js#L531-L538