### PR TITLE
Fix/tao 9654 refactor back button

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.10.3',
+    'version' => '2.10.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -264,6 +264,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.6.0');
         }
 
-        $this->skip('2.6.0', '2.10.3');
+        $this->skip('2.6.0', '2.10.4');
     }
 }

--- a/views/js/test/runner/plugins/navigation/limitBackButton/test.html
+++ b/views/js/test/runner/plugins/navigation/limitBackButton/test.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="latency.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="limitBackButton"></script>
 
         <script  type="text/javascript">
 

--- a/views/js/test/runner/plugins/navigation/limitBackButton/test.js
+++ b/views/js/test/runner/plugins/navigation/limitBackButton/test.js
@@ -20,12 +20,14 @@
  */
 
 define([
+    'jquery',
+    'core/eventifier',
     'taoTests/runner/runner',
+    'taoTests/runner/plugin',
     'taoTestRunnerPlugins/runner/plugins/navigation/limitBackButton'
-], function(runnerFactory, pluginFactory) {
+], function($, eventifier, runnerFactory, pluginFactory, limitBackButtonPluginFactory) {
     'use strict';
 
-    var pluginApi;
     var providerName = 'mock';
     runnerFactory.registerProvider(providerName, {
         name: providerName,
@@ -34,35 +36,217 @@ define([
         init(){ }
     });
 
-    /**
-     * The following tests applies to all plugins
-     */
+
     QUnit.module('pluginFactory');
 
     QUnit.test('module', function(assert) {
         var runner = runnerFactory(providerName);
 
-        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
-        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
-        assert.notStrictEqual(pluginFactory(runner), pluginFactory(runner), 'The plugin factory provides a different instance on each call');
+        assert.equal(typeof limitBackButtonPluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof limitBackButtonPluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(limitBackButtonPluginFactory(runner), limitBackButtonPluginFactory(runner), 'The plugin factory provides a different instance on each call');
     });
 
-    pluginApi = [
-        {
-            name: 'init',
-            title: 'init'
-        },
-        {
-            name: 'destroy',
-            title: 'destroy'
-        }
-    ];
-
     QUnit
-        .cases.init(pluginApi)
-        .test('plugin API ', function(data, assert) {
+        .cases.init(['install', 'init', 'destroy'])
+        .test('plugin API ', (method, assert) => {
             var runner = runnerFactory(providerName);
-            var plugin = pluginFactory(runner);
-            assert.equal(typeof plugin[data.name], 'function', 'The pluginFactory instances expose a "' + data.name + '" function');
+            var plugin = limitBackButtonPluginFactory(runner);
+            assert.equal(typeof plugin[method], 'function', `The pluginFactory instances expose a "${method}" method`);
         });
+
+
+    QUnit.module('behavior');
+
+    QUnit.test('disable on change', assert => {
+        const store = {};
+        let previousButtonEnabled = true;
+        const done = assert.async();
+
+        assert.expect(8);
+
+        runnerFactory.registerProvider('limitBackMock', {
+            name: 'limitBackMock',
+            loadAreaBroker(){
+                return {
+                    getContainer(){
+                        return $('#qunit-fixtures');
+                    }
+                };
+            },
+            loadProxy(){ },
+            loadTestStore(){
+                return {
+                    getStore() {
+                        return Promise.resolve({
+                            getItem(key){
+                                return Promise.resolve(store[key]);
+                            },
+                            setItem(key, value){
+                                store[key] = value;
+                                return Promise.resolve(true);
+                            }
+                        });
+                    }
+                };
+            },
+            init(){ }
+        });
+
+        const runner = runnerFactory('limitBackMock', [
+            pluginFactory({
+                name : 'previous',
+                init(){},
+                enable(){
+                    previousButtonEnabled = true;
+                },
+                disable(){
+                    previousButtonEnabled = false;
+                }
+            }),
+            limitBackButtonPluginFactory
+        ]);
+
+        runner.itemRunner = eventifier();
+
+        runner.on('init', () => {
+            const previous = runner.getPlugin('previous');
+            const limitBackButton = runner.getPlugin('limitBackButton');
+
+            assert.equal(typeof previous, 'object');
+            assert.equal(typeof limitBackButton, 'object');
+
+            assert.equal(previousButtonEnabled, true, 'The back button is enabled');
+            assert.equal(typeof store['item1'], 'undefined', 'The item value is not yet stored');
+
+            runner.on('renderitem', () => {
+
+                assert.equal(previousButtonEnabled, true, 'The back button remains enabled');
+                assert.equal(typeof store['item1'], 'undefined', 'The item value is not yet stored');
+
+                runner.trigger('plugin-responsechange.limitBackButton');
+
+                setTimeout(function(){
+
+                    assert.equal(previousButtonEnabled, false, 'The back button is disabled');
+                    assert.equal(store['item1'], true, 'The item has been flagged as answered');
+
+                    done();
+                }, 5);
+            })
+            .trigger('loaditem', 'item1')
+            .trigger('renderitem', 'item1');
+        })
+        .on('error', err => {
+            assert.ok(false, err.message);
+            done();
+        })
+        .init();
+    });
+
+
+    QUnit.test('enabled back after navigation to a new item', assert => {
+        const store = {};
+        let previousButtonEnabled = true;
+        const done = assert.async();
+
+        assert.expect(14);
+
+        runnerFactory.registerProvider('limitBackMock', {
+            name: 'limitBackMock',
+            loadAreaBroker(){
+                return {
+                    getContainer(){
+                        return $('#qunit-fixtures');
+                    }
+                };
+            },
+            loadProxy(){ },
+            loadTestStore(){
+                return {
+                    getStore() {
+                        return Promise.resolve({
+                            getItem(key){
+                                return Promise.resolve(store[key]);
+                            },
+                            setItem(key, value){
+                                store[key] = value;
+                                return Promise.resolve(true);
+                            }
+                        });
+                    }
+                };
+            },
+            init(){ }
+        });
+
+        const runner = runnerFactory('limitBackMock', [
+            pluginFactory({
+                name : 'previous',
+                init(){},
+                enable(){
+                    previousButtonEnabled = true;
+                },
+                disable(){
+                    previousButtonEnabled = false;
+                }
+            }),
+            limitBackButtonPluginFactory
+        ]);
+
+        runner.itemRunner = eventifier();
+
+        runner.on('init', () => {
+            const previous = runner.getPlugin('previous');
+            const limitBackButton = runner.getPlugin('limitBackButton');
+
+            assert.equal(typeof previous, 'object');
+            assert.equal(typeof limitBackButton, 'object');
+
+            assert.equal(previousButtonEnabled, true, 'The back button is enabled');
+            assert.equal(typeof store['item1'], 'undefined', 'The item value is not yet stored');
+            assert.equal(typeof store['item2'], 'undefined', 'The item value is not yet stored');
+
+            runner.on('renderitem.item1', () => {
+                runner.off('renderitem.item1');
+
+                assert.equal(previousButtonEnabled, true, 'The back button remains enabled');
+                assert.equal(typeof store['item1'], 'undefined', 'The item value is not yet stored');
+                assert.equal(typeof store['item2'], 'undefined', 'The item value is not yet stored');
+
+                runner.trigger('plugin-responsechange.limitBackButton');
+
+                setTimeout(() => {
+
+                    assert.equal(previousButtonEnabled, false, 'The back button is disabled');
+                    assert.equal(store['item1'], true, 'The item has been flagged as answered');
+                    assert.equal(typeof store['item2'], 'undefined', 'The item value is not yet stored');
+
+                    runner.trigger('unloaditem')
+                          .trigger('disablenav')
+                          .trigger('loaditem', 'item2')
+                          .trigger('renderitem.item2', 'item2')
+                          .trigger('enablenav');
+                }, 5);
+            })
+            .on('renderitem.item2', () => {
+
+                setTimeout(() => {
+                    assert.equal(previousButtonEnabled, true, 'The back button is enabled again');
+                    assert.equal(store['item1'], true, 'The item has been flagged as answered');
+                    assert.equal(typeof store['item2'], 'undefined', 'The item value is still not stored');
+                    done();
+
+                }, 5);
+            })
+            .trigger('loaditem', 'item1')
+            .trigger('renderitem.item1', 'item1');
+
+        })
+        .on('error', err => {
+            assert.ok(false, err.message);
+            done();
+        })
+        .init();
+    });
 });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-9654

 - Fix the back button issue that was re enabled on some events (when a popup was displayed for example) 
  - Refactor and clean up the code
  - Add a unit test

How to test : 
 - enable the plugin
 - take a non linear test
 - ensure response validation is setup and allowSkipping is also set
 - you can navifgate back only if you have answered already
 - the state is kept (already answered and you can't go back)
 - try to navigate next and and change the response, the behavior should stay consistent