### PR TITLE
Feature/nec 40/Improve the answerCache plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.10.4',
+    'version' => '2.11.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -33,7 +33,7 @@ use oat\taoTests\models\runner\plugins\TestPlugin;
  */
 class RegisterTestRunnerPlugins extends InstallAction
 {
-    public static $plugins = [
+    protected $plugins = [
         'content' => [
             [
                 'id' => 'answerCache',
@@ -154,23 +154,89 @@ class RegisterTestRunnerPlugins extends InstallAction
         ],
     ];
 
-    /**
-     * Run the install action
-     */
-    public function __invoke($params)
-    {
+    protected $configs = [
+        'answerCache' => [
+            'config' => [
+                'allAttempts' => false
+            ]
+        ]
+    ];
 
+    /**
+     * @return Report
+     * @throws \common_exception_InconsistentData
+     */
+    protected function registerPlugins()
+    {
         $registry = PluginRegistry::getRegistry();
         $count = 0;
 
-        foreach(self::$plugins as $categoryPlugins) {
-            foreach($categoryPlugins as $pluginData){
-                if( $registry->register(TestPlugin::fromArray($pluginData)) ) {
+        foreach ($this->plugins as $categoryPlugins) {
+            foreach ($categoryPlugins as $pluginData) {
+                if ($registry->register(TestPlugin::fromArray($pluginData))) {
                     $count++;
                 }
             }
         }
 
-        return new Report(Report::TYPE_SUCCESS, $count .  ' plugins registered.');
+        return new Report(Report::TYPE_SUCCESS, $count . ' plugins registered.');
+    }
+
+    /**
+     * @return Report
+     */
+    protected function configurePlugins()
+    {
+        $extension = $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
+        $config = $extension->getConfig('testRunner');
+        $count = 0;
+
+        foreach ($this->configs as $pluginName => $pluginConfig) {
+            $configured = false;
+
+            if (isset($pluginConfig['id'])) {
+                $pluginName = $pluginConfig['id'];
+            }
+
+            if (isset($pluginConfig['shortcuts']) && count($pluginConfig['shortcuts'])) {
+                $config['shortcuts'][$pluginName] = $pluginConfig['shortcuts'];
+                $configured = true;
+            }
+
+            if (isset($pluginConfig['config']) && count($pluginConfig['config'])) {
+                $config['plugins'][$pluginName] = $pluginConfig['config'];
+                $configured = true;
+            }
+
+            if ($configured) {
+                $count ++;
+            }
+        }
+
+        $extension->setConfig('testRunner', $config);
+
+        return new Report(Report::TYPE_SUCCESS, $count . ' plugins configured.');
+    }
+
+    /**
+     * Run the install action
+     * @param $params
+     * @return Report
+     * @throws \common_exception_Error
+     * @throws \common_exception_InconsistentData
+     */
+    public function __invoke($params)
+    {
+        $registered = $this->registerPlugins();
+        $configured = $this->configurePlugins();
+
+        $overall = new Report(Report::TYPE_SUCCESS, 'Plugins registration done!');
+        $overall->add($registered);
+        $overall->add($configured);
+        if ($overall->containsError()) {
+            $overall->setType(Report::TYPE_ERROR);
+        }
+
+        return $overall;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -265,5 +265,14 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('2.6.0', '2.10.4');
+
+        if ($this->isVersion('2.10.4')) {
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['plugins']['answerCache']['allAttempts'] = false;
+            $extension->setConfig('testRunner', $config);
+
+            $this->setVersion('2.11.0');
+        }
     }
 }

--- a/views/js/test/runner/plugins/content/answerCache/test.html
+++ b/views/js/test/runner/plugins/content/answerCache/test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner Plugins - Answer Cache</title>
+        <base href="../../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoTestRunnerPlugins/test/runner/plugins/content/answerCache/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/plugins/content/answerCache/test.js
+++ b/views/js/test/runner/plugins/content/answerCache/test.js
@@ -1,0 +1,180 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+define([
+    'jquery',
+    'core/eventifier',
+    'taoTests/runner/runner',
+    'taoTests/runner/plugin',
+    'taoTestRunnerPlugins/runner/plugins/content/answerCache'
+], function (
+    $,
+    eventifier,
+    runnerFactory,
+    pluginFactory,
+    answerCachePluginFactory
+) {
+    'use strict';
+
+    const providerName = 'mock';
+    runnerFactory.registerProvider(providerName, {
+        name: providerName,
+        loadAreaBroker() {},
+        loadProxy() {},
+        init() {}
+    });
+
+
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
+
+        assert.equal(typeof answerCachePluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof answerCachePluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(answerCachePluginFactory(runner), answerCachePluginFactory(runner), 'The plugin factory provides a different instance on each call');
+    });
+
+    QUnit
+        .cases.init([
+            {title: 'install'},
+            {title: 'init'},
+            {title: 'destroy'}
+        ])
+        .test('plugin API ', (data, assert) => {
+            const runner = runnerFactory(providerName);
+            const plugin = answerCachePluginFactory(runner);
+            assert.equal(typeof plugin[data.title], 'function', `The pluginFactory instances expose a "${data.title}" method`);
+        });
+
+    QUnit.module('behavior');
+
+    QUnit.test('Reload answers', assert => {
+        const done = assert.async();
+        const localProviderName = 'answerCacheMock';
+        const store = {};
+        const emptyState = {
+            base: {
+                string: ''
+            }
+        };
+        const changedState = {
+            base: {
+                string: 'abcd'
+            }
+        };
+        let state = emptyState;
+
+        assert.expect(5);
+
+        runnerFactory.registerProvider(localProviderName, {
+            name: localProviderName,
+            loadAreaBroker() {},
+            loadProxy() {},
+            loadTestStore() {
+                return {
+                    getStore() {
+                        return Promise.resolve({
+                            getItem(key) {
+                                return Promise.resolve(store[key]);
+                            },
+                            setItem(key, value) {
+                                store[key] = value;
+                                return Promise.resolve(true);
+                            }
+                        });
+                    }
+                };
+            },
+            init() {},
+            renderItem() {
+                this.itemRunner = eventifier({
+                    _item: {
+                        responses: {
+                            responsedeclaration_5df3b12bb96b9184208345: {
+                                attributes: {
+                                    identifier: 'RESPONSE',
+                                    cardinality: 'single',
+                                    baseType: 'string'
+                                },
+                                defaultValue: []
+                            }
+                        }
+                    },
+                    getResponses() {
+                        return {
+                            RESPONSE: state
+                        };
+                    },
+                    setResponses(response) {
+                        this.setState(response);
+                        this.trigger('responsechange');
+                    },
+                    getState() {
+                        return state;
+                    },
+                    setState(newState) {
+                        state = newState;
+                    }
+                });
+            }
+        });
+
+        const runner = runnerFactory(localProviderName, [answerCachePluginFactory]);
+
+        runner
+            .on('init', () => {
+                assert.ok(true, 'Runner has been initialized');
+                runner.setTestContext({
+                    itemIdentifier: 'item-1',
+                    attempt: 1
+                });
+                runner.renderItem('item-1', {});
+            })
+            .on('renderitem', () => {
+                Promise.resolve()
+                    .then(() => new Promise(resolve => {
+                        window.setTimeout(() => {
+                            assert.equal(typeof runner.itemRunner, 'object', 'The item runner is set');
+                            assert.deepEqual(runner.itemRunner.getState(), emptyState, 'The item state is empty');
+                            resolve();
+                        }, 100);
+                    }))
+                    .then(() => new Promise(resolve => {
+                        runner.itemRunner.setResponses(changedState);
+                        window.setTimeout(() => {
+                            assert.deepEqual(runner.itemRunner.getState(), changedState, 'The item state has changed');
+                            assert.deepEqual(store['item-1'], changedState, 'The item state has changed');
+                            resolve();
+                        }, 100);
+                    }))
+                    .then(() => {
+                        runner.destroy();
+                    });
+            })
+            .on('destroy', done)
+            .on('error', err => {
+                assert.ok(false, err.message);
+                done();
+            })
+            .init();
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEC-40

Rework the answer cache plugin:
- add an option to take care of all item attempts, instead of the first one only
- make it resilient to navigation issues: clear the cache only after having successfully reached the next step in the navigation (resilient to connectivity issues as well as session timeout or disconnections)

How to test it:
- install the extension `taoTestRunnerPlugins`
- enable the `answerCache` plugin (in the file `config/taoTests/test_runner_plugin_registry.conf.php`)
- set the plugin option `allAttempts` to true (in the file `config/taoQtiTest/testRunner.conf.php`)
- take a test
    - answer to an item
    - refresh the page
    - the answer should be reloaded
- take a test
    - answer to an item
    - stop the server
    - go to next item, the test should fail
    - restart the server
    - refresh the page
    - the answer should be reloaded
- take a test
    - answer to an item
    - kill the session (you may open another tab on the same session, using the home link, and logout the user)
    - reconnect and resume the test
    - the answer should be reloaded

Unit tests should work:
```
cd tao/views/build
npx grunt connect:dev taotestrunnerpluginstest
```

Or from the browser: `http://<YOUR_HOST>/taoTestRunnerPlugins/views/js/test/runner/plugins/content/answerCache/test.html`

Impacted test: `taoTestRunnerPlugins/views/js/test/runner/plugins/content/answerCache/test.html`