### PR TITLE
Feature/nec 39/add session heartbeat plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.11.0',
+    'version' => '2.12.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -46,6 +46,18 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'tags' => [ ]
             ]
         ],
+        'controls' => [
+            [
+                'id' => 'sessionHeartbeat',
+                'name' => 'Session Heartbeat',
+                'module' => 'taoTestRunnerPlugins/runner/plugins/controls/sessionHeartbeat',
+                'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
+                'description' => 'Send a regular signal to keep the session alive',
+                'category' => 'controls',
+                'active' => false,
+                'tags' => [ ]
+            ]
+        ],
         'navigation' => [
             [
                 'id' => 'limitBackButton',
@@ -158,6 +170,12 @@ class RegisterTestRunnerPlugins extends InstallAction
         'answerCache' => [
             'config' => [
                 'allAttempts' => false
+            ]
+        ],
+        'sessionHeartbeat' => [
+            'config' => [
+                'interval' => '900',
+                'action' => 'up'
             ]
         ]
     ];

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -274,5 +274,29 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('2.11.0');
         }
+
+        if ($this->isVersion('2.11.0')) {
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['plugins']['sessionHeartbeat'] = [
+                'interval' => '900',
+                'action' => 'up'
+            ];
+            $extension->setConfig('testRunner', $config);
+
+            $registry = PluginRegistry::getRegistry();
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'sessionHeartbeat',
+                'name' => 'Session Heartbeat',
+                'module' => 'taoTestRunnerPlugins/runner/plugins/controls/sessionHeartbeat',
+                'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
+                'description' => 'Send a regular signal to keep the session alive',
+                'category' => 'controls',
+                'active' => false,
+                'tags' => [ ]
+            ]));
+
+            $this->setVersion('2.12.0');
+        }
     }
 }

--- a/views/js/runner/plugins/controls/sessionHeartbeat.js
+++ b/views/js/runner/plugins/controls/sessionHeartbeat.js
@@ -1,0 +1,98 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Plugin that sends a heartbeat signal to maintain the session alive.
+ * The ideal interval should between half and full duration of the session.
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'util/namespace',
+    'taoTests/runner/plugin',
+    'core/polling'
+], function (_, namespaceHelper, pluginFactory, pollingFactory) {
+    'use strict';
+
+    /**
+     * Some default values
+     * @type {Object}
+     */
+    const defaultConfig = {
+        interval: 900,  // The interval between two heartbeat signals, in seconds
+        action: 'up'
+    };
+
+    /**
+     * The number of milliseconds in one interval unit
+     * @type {Number}
+     */
+    const intervalUnit = 1000;
+
+    /**
+     * Returns the configured plugin
+     */
+    return pluginFactory({
+
+        name: 'sessionHeartbeat',
+
+        /**
+         * Initializes the plugin (called during runner's init)
+         */
+        init() {
+            const testRunner = this.getTestRunner();
+            const {interval, action} = _.defaults(this.getConfig() || {}, defaultConfig);
+
+            this.polling = pollingFactory({
+                action() {
+                    const testContext = testRunner.getTestContext();
+                    testRunner.getProxy().telemetry(testContext.itemIdentifier, action);
+                },
+                interval: interval * intervalUnit,
+                autoStart: true
+            });
+        },
+
+        /**
+         * Called during the runner's destroy phase
+         */
+        destroy() {
+            if (this.polling) {
+                this.polling.stop();
+            }
+            this.polling = null;
+        },
+
+        /**
+         * Enables the button
+         */
+        enable() {
+            if (this.polling) {
+                this.polling.start();
+            }
+        },
+
+        /**
+         * Disables the button
+         */
+        disable() {
+            if (this.polling) {
+                this.polling.stop();
+            }
+        }
+    });
+});

--- a/views/js/test/runner/plugins/controls/sessionHeartbeat/test.html
+++ b/views/js/test/runner/plugins/controls/sessionHeartbeat/test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner Plugins - Session Heartbeat</title>
+        <base href="../../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoTestRunnerPlugins/test/runner/plugins/controls/sessionHeartbeat/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/plugins/controls/sessionHeartbeat/test.js
+++ b/views/js/test/runner/plugins/controls/sessionHeartbeat/test.js
@@ -1,0 +1,169 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+define([
+    'jquery',
+    'lodash',
+    'core/eventifier',
+    'taoTests/runner/runner',
+    'taoTests/runner/proxy',
+    'taoTests/runner/plugin',
+    'taoTestRunnerPlugins/runner/plugins/controls/sessionHeartbeat'
+], function (
+    $,
+    _,
+    eventifier,
+    runnerFactory,
+    proxyFactory,
+    pluginFactory,
+    sessionHeartbeatPluginFactory
+) {
+    'use strict';
+
+    const providerName = 'mock';
+    runnerFactory.registerProvider(providerName, {
+        name: providerName,
+        loadAreaBroker() {},
+        loadProxy() {},
+        init() {}
+    });
+
+    /**
+     * Mocks an item runner
+     * @param {Object} initialState
+     * @returns {itemRunner}
+     */
+    function getItemRunnerMock(initialState) {
+        let state = initialState;
+        return eventifier({
+            getResponses() {
+                return {};
+            },
+            setResponses(response) {
+                this.setState(response);
+                this.trigger('responsechange');
+            },
+            getState() {
+                return state;
+            },
+            setState(newState) {
+                state = newState;
+            }
+        });
+    }
+
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
+
+        assert.equal(typeof sessionHeartbeatPluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof sessionHeartbeatPluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(sessionHeartbeatPluginFactory(runner), sessionHeartbeatPluginFactory(runner), 'The plugin factory provides a different instance on each call');
+    });
+
+    QUnit
+        .cases.init([
+            {title: 'install'},
+            {title: 'init'},
+            {title: 'destroy'}
+        ])
+        .test('plugin API ', (data, assert) => {
+            const runner = runnerFactory(providerName);
+            const plugin = sessionHeartbeatPluginFactory(runner);
+            assert.equal(typeof plugin[data.title], 'function', `The pluginFactory instances expose a "${data.title}" method`);
+        });
+
+    QUnit.module('behavior');
+
+    QUnit.test('Send signal', assert => {
+        const done = assert.async();
+        const localProviderName = 'sessionHeartbeatMock';
+        const itemIdentifier = 'item-1';
+        const expectedCount = 3;
+        let count = 0;
+
+        assert.expect(1 + expectedCount * 2);
+
+        runnerFactory.registerProvider(localProviderName, {
+            name: localProviderName,
+            loadAreaBroker() {},
+            loadProxy() {
+                const self = this;
+
+                proxyFactory.registerProvider(localProviderName, {
+                    install() {},
+                    init() {},
+                    telemetry(itemId, action) {
+                        assert.ok(itemId, itemIdentifier, 'The heartbeat signal has been sent');
+                        assert.ok(action, 'foo', 'The right endpoint is called');
+                        if (++count >= expectedCount) {
+                            self.destroy();
+                        }
+                    }
+                });
+                return proxyFactory(localProviderName, {});
+            },
+            loadTestStore() {},
+            init() {
+                const plugins = this.getPlugins() || {};
+                const pluginsConfig = this.getPluginsConfig() || {};
+                this.setTestContext({itemIdentifier});
+
+                _.forEach(pluginsConfig, (config, pluginName) => {
+                    plugins[pluginName].setConfig(config);
+                });
+
+                return this.getProxy().init();
+            },
+            renderItem() {
+                this.itemRunner = getItemRunnerMock({});
+            }
+        });
+
+        const runner = runnerFactory(localProviderName, [sessionHeartbeatPluginFactory], {
+            options: {
+                plugins: {
+                    sessionHeartbeat: {
+                        interval: 0.1,
+                        action: 'foo'
+                    }
+                }
+            }
+        });
+
+        runner
+            .on('init', () => {
+                assert.ok(true, 'Runner has been initialized');
+                window.setTimeout(() => {
+                    if (count < expectedCount) {
+                        runner.destroy();
+                    }
+                }, 1000);
+            })
+            .on('destroy', done)
+            .on('error', err => {
+                assert.ok(false, err.message);
+                done();
+            })
+            .init();
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEC-39

Requires: 
 - [ ] https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/139

Implement a very simple session heartbeat signal. The plugin will send a telemetry signal every N minutes to maintain the session alive. By default, the interval is 15 minutes.

Note: the companion PR is needed as the install script has been improved in it. So it should be merged first.

How to test:
- install the extension `taoTestRunnerPlugins`
- enable the `sessionHeartbeat` plugin (in the file `config/taoTests/test_runner_plugin_registry.conf.php`)
- set the plugin option `interval` to a short enough interval, the value being given in seconds (in the file `config/taoQtiTest/testRunner.conf.php`)
- take a test
- observe the network, a regular `up` request should be visible, and should take a very small time to be performed.


Unit tests should work:
```
cd tao/views/build
npx grunt connect:dev taotestrunnerpluginstest
```

Or from the browser: `http://<YOUR_HOST>/taoTestRunnerPlugins/views/js/test/runner/plugins/controls/sessionHeartbeat/test.html`

Impacted test: `taoTestRunnerPlugins/views/js/test/runner/plugins/controls/sessionHeartbeat/test.html`
