### PR TITLE
Proper terminated status for interrupted sessions in the offline mode

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.12.0',
+    'version' => '2.13.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/model/offline/JsonOfflineTestImporter.php
+++ b/model/offline/JsonOfflineTestImporter.php
@@ -120,6 +120,7 @@ class JsonOfflineTestImporter implements \tao_models_classes_import_ImportHandle
         } catch (\Exception $e) {
             $this->report = Report::createFailure(__('Fail to import test actions with message: '. $e->getMessage()));
         }
+
         $this->getUploadService()->remove($uploadedFile);
 
         return $this->report;
@@ -189,7 +190,9 @@ class JsonOfflineTestImporter implements \tao_models_classes_import_ImportHandle
      */
     protected function importActions()
     {
-        $data = $this->getOfflineParser()->getActionsQueue();
+        $parsedSession = $this->getOfflineParser();
+
+        $data = $parsedSession->getActionsQueue();
 
         if (!$data) {
             throw new \common_Exception(__('Cannot find any actions for importing.'));
@@ -201,7 +204,7 @@ class JsonOfflineTestImporter implements \tao_models_classes_import_ImportHandle
         ];
 
         /** @var DeliveryExecutionInterface $deliveryExecution */
-        $deliveryExecution = $this->getProxyService()->getDeliveryExecution($this->getOfflineParser()->getSessionId());
+        $deliveryExecution = $this->getProxyService()->getDeliveryExecution($parsedSession->getSessionId());
 
         if ($deliveryExecution->getState()->getUri() !== DeliveryExecutionInterface::STATE_ACTIVE) {
             throw new \common_Exception(__('Delivery execution %s is not active state.', $deliveryExecution->getIdentifier()));
@@ -212,7 +215,7 @@ class JsonOfflineTestImporter implements \tao_models_classes_import_ImportHandle
 
         $testState = DeliveryExecutionInterface::STATE_TERMINATED;
 
-        if (!$this->getOfflineParser()->isInterrupted()) {
+        if (!$parsedSession->isInterrupted()) {
 
             /** @var AssessmentTestSession $testSession */
             $testSession = $serviceContext->getTestSession();
@@ -236,7 +239,8 @@ class JsonOfflineTestImporter implements \tao_models_classes_import_ImportHandle
         $successReport = Report::createSuccess(
             __('%s actions were successfully imported', count($data))
         );
-        $successReport->setData(['uriResource' => $this->getOfflineParser()->getSessionId()]);
+
+        $successReport->setData(['uriResource' => $parsedSession->getSessionId()]);
 
         $this->report->add($successReport);
     }

--- a/model/offline/JsonOfflineTestParser.php
+++ b/model/offline/JsonOfflineTestParser.php
@@ -29,6 +29,8 @@ use oat\oatbox\filesystem\File;
  */
 class JsonOfflineTestParser implements OfflineTestParserInterface
 {
+    const KEY_IS_EXIT_TEST = 'isExitTest';
+
     /** @var string */
     private $content;
 
@@ -112,5 +114,14 @@ class JsonOfflineTestParser implements OfflineTestParserInterface
         $body = $this->getBody();
         $testConfig = $body['testConfig'];
         return (isset($testConfig[$key]) && $testConfig[$key]) ? $testConfig[$key] : null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInterrupted()
+    {
+        $body = $this->getBody();
+        return isset($body[self::KEY_IS_EXIT_TEST]) ? (bool) $body[self::KEY_IS_EXIT_TEST] : false;
     }
 }

--- a/model/offline/JsonOfflineTestParser.php
+++ b/model/offline/JsonOfflineTestParser.php
@@ -86,8 +86,7 @@ class JsonOfflineTestParser implements OfflineTestParserInterface
     public function getActionsQueue()
     {
         $body = $this->getBody();
-        $actionQueue = isset($body['actionQueue']) ? $body['actionQueue'] : [];
-        return $actionQueue;
+        return $body['actionQueue'] ?? [];
     }
 
     /**
@@ -119,9 +118,14 @@ class JsonOfflineTestParser implements OfflineTestParserInterface
     /**
      * @return bool
      */
-    public function isInterrupted()
+    public function isInterrupted(): bool
     {
         $body = $this->getBody();
-        return isset($body[self::KEY_IS_EXIT_TEST]) ? (bool) $body[self::KEY_IS_EXIT_TEST] : false;
+
+        if (isset($body[self::KEY_IS_EXIT_TEST])) {
+            return filter_var($body[self::KEY_IS_EXIT_TEST], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return false;
     }
 }

--- a/model/offline/OfflineTestParserInterface.php
+++ b/model/offline/OfflineTestParserInterface.php
@@ -52,4 +52,10 @@ interface OfflineTestParserInterface
      * @return mixed
      */
     public function getTestConfig($key);
+
+    /**
+     * Returns true if test was interrupted by user
+     * @return bool
+     */
+    public function isInterrupted();
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -298,5 +298,7 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('2.12.0');
         }
+
+        $this->skip('2.12.0', '2.13.0');
     }
 }

--- a/test/integration/samples/json/sample-interrupted.json
+++ b/test/integration/samples/json/sample-interrupted.json
@@ -1,5 +1,5 @@
 {
-  "isExitTest": false,
+  "isExitTest": true,
   "timestamp": 1546612795762,
   "testData": {
     "title": "Test 2",

--- a/test/unit/model/offline/JsonOfflineTestParserTest.php
+++ b/test/unit/model/offline/JsonOfflineTestParserTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTestRunnerPlugins\test\unit\model\offline;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\filesystem\File;
+use oat\taoTestRunnerPlugins\model\offline\JsonOfflineTestParser;
+
+class JsonOfflineTestParserTest extends TestCase
+{
+    /**
+     * @dataProvider isInterruptedDataProvider
+     *
+     * @param $json
+     * @param $expected
+     */
+    public function testIsInterrupted($json, $expected)
+    {
+        /** @var File $file */
+        $file = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $file->method('read')
+            ->willReturn($json);
+
+        $parser = new JsonOfflineTestParser($file);
+
+        $this->assertEquals($parser->isInterrupted(), $expected);
+    }
+
+    public function isInterruptedDataProvider()
+    {
+        return [
+            ['{}', false],
+            ['{"isExitTest":true}', true],
+            ['{"isExitTest":"true"}', true],
+            ['{"isExitTest":false}', false],
+            ['{"isExitTest":"false"}', false],
+            ['{"isExitTest":null}', false],
+            ['{"isExitTest":1}', true],
+            ['{"isExitTest":0}', false],
+        ];
+    }
+}


### PR DESCRIPTION
Task is https://oat-sa.atlassian.net/browse/TAO-9959

Requires https://github.com/oat-sa/tao-test-runner-qti-fe/pull/109

It checks a new parameter that comes from JSON during uploading offline results that say that the test was interrupted by the user. In this case, it does not finish the test but sets it to the terminated state and this test can be restored using REST endpoint `/taoDelivery/RestExecution/unstop`.

Now test always finished and restoring impossible.

To test this PR need to be in configured offline mode, create any delivery, run test, turn offline mode (turn off internet connection) and try to pass some items and exit from the test and wait for the file with offline results. Upload this file in the back office and after that try to restore the session.

To turn the offline mode need to run: `php index.php "oat\taoQtiTest\scripts\install\SetOfflineTestRunnerConfig"`
To run restoring session use the following script (as example):
```
curl -H "Content-Type: application/x-www-form-urlencoded" -H "Accept: application/json" -X POST -d 'deliveryExecution=https://nfer.local.docker/tao.rdf#i5e1e2782103a3718ed5ffeaa5f66dd' 'https://admin:password@nfer.local.docker/taoDelivery/RestExecution/unstop'
```