### PR TITLE
INV-52: Fix/inv 52/drag n drop issue  in Mozilla

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.13.0',
+    'version' => '2.13.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -299,6 +299,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.12.0');
         }
 
-        $this->skip('2.12.0', '2.13.0');
+        $this->skip('2.12.0', '2.13.1');
     }
 }

--- a/views/js/runner/plugins/tools/preventDropToInput.js
+++ b/views/js/runner/plugins/tools/preventDropToInput.js
@@ -54,7 +54,7 @@ define([
             var testRunner = self.getTestRunner();
 
             this.getTestRunner()
-                .after('renderitem', function () {
+                .after('renderitem', function renderItem() {
                     var config = _.defaults((self.getConfig() || {}), _defaults);
                     var $items = testRunner.getAreaBroker().getContentArea().find(config.selector);
                     var disabled = {};
@@ -78,14 +78,13 @@ define([
                             });
                         })
                         .on(namespaceHelper.namespaceAll('dragend', 'preventdropimg'), function handleDragEnd(event) {
-                            event.preventDefault();
                             _.forEach($items, function (el, key) {
                                 var $el = $(el);
                                 $el.prop('disabled', disabled[key]);
                             });
                             disabled = {};
                         });
-                }).on('destroy', function() {
+                }).on('destroy', function destroy() {
                     var config = _.defaults((self.getConfig() || {}), _defaults);
                     $(config.draggableSelector).off('.preventdropimg');
                 });

--- a/views/js/runner/plugins/tools/preventDropToInput.js
+++ b/views/js/runner/plugins/tools/preventDropToInput.js
@@ -77,7 +77,7 @@ define([
                                 $el.prop('disabled', true);
                             });
                         })
-                        .on(namespaceHelper.namespaceAll('dragend', 'preventdropimg'), function handleDragEnd(event) {
+                        .on(namespaceHelper.namespaceAll('dragend', 'preventdropimg'), function handleDragEnd() {
                             _.forEach($items, function (el, key) {
                                 var $el = $(el);
                                 $el.prop('disabled', disabled[key]);

--- a/views/js/runner/plugins/tools/preventDropToInput.js
+++ b/views/js/runner/plugins/tools/preventDropToInput.js
@@ -57,30 +57,33 @@ define([
                 .after('renderitem', function () {
                     var config = _.defaults((self.getConfig() || {}), _defaults);
                     var $items = testRunner.getAreaBroker().getContentArea().find(config.selector);
-                    var disabled = [];
+                    var disabled = {};
 
                     $(config.draggableSelector)
                         .off('.preventdropimg')
-                        .on(namespaceHelper.namespaceAll('dragstart', 'preventdropimg'), function (event) {
+                        .on(namespaceHelper.namespaceAll('dragstart', 'preventdropimg'), function handleDragStart(e) {
+                            /**
+                             * Workaround for Mozilla browser:
+                             * In some cases the `dragend` event doesn't fire.
+                             * We set event.dataTransfer.setDragImage in order to force it to be fired
+                             */
+                            var target = e.originalEvent.target;
+                            e.originalEvent.dataTransfer.setData("text/plain", target.id);
+                            e.originalEvent.dataTransfer.setDragImage(target, 0, 0);
+
                             _.forEach($items, function (el, key) {
                                 var $el = $(el);
                                 disabled[key] = !!$el.prop('disabled');
                                 $el.prop('disabled', true);
                             });
                         })
-                        .on(namespaceHelper.namespaceAll('dragend', 'preventdropimg'), function (event) {
+                        .on(namespaceHelper.namespaceAll('dragend', 'preventdropimg'), function handleDragEnd(event) {
+                            event.preventDefault();
                             _.forEach($items, function (el, key) {
                                 var $el = $(el);
                                 $el.prop('disabled', disabled[key]);
                             });
-                            disabled = [];
-                        })
-                        .on(namespaceHelper.namespaceAll('dragleave', 'preventdropimg'), function (event) {
-                            _.forEach($items, function (el, key) {
-                                var $el = $(el);
-                                $el.prop('disabled', disabled[key]);
-                            });
-                            disabled = [];
+                            disabled = {};
                         });
                 }).on('destroy', function() {
                     var config = _.defaults((self.getConfig() || {}), _defaults);

--- a/views/js/runner/plugins/tools/preventDropToInput.js
+++ b/views/js/runner/plugins/tools/preventDropToInput.js
@@ -74,6 +74,13 @@ define([
                                 $el.prop('disabled', disabled[key]);
                             });
                             disabled = [];
+                        })
+                        .on(namespaceHelper.namespaceAll('dragleave', 'preventdropimg'), function (event) {
+                            _.forEach($items, function (el, key) {
+                                var $el = $(el);
+                                $el.prop('disabled', disabled[key]);
+                            });
+                            disabled = [];
                         });
                 }).on('destroy', function() {
                     var config = _.defaults((self.getConfig() || {}), _defaults);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/INV-52

### Description
Found out that there’s a known issue for Mozilla which in some cases doesn’t fire the drugend event at the end of the drag&drop action. The `preventDropToInput` plugin makes the target element (textarea) disabled on drag start, and in case of the mentioned issue the pluging doesn’t restore (un-disable) the textarea.


