### PR TITLE
add ability to copy-paste in input fields with enabled security plugins

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.14.1',
+    'version' => '2.14.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -299,6 +299,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.12.0');
         }
 
-        $this->skip('2.12.0', '2.14.1');
+        $this->skip('2.12.0', '2.14.2');
     }
 }

--- a/views/js/runner/plugins/security/disableCommands.js
+++ b/views/js/runner/plugins/security/disableCommands.js
@@ -63,7 +63,17 @@ define([
      * A list of shortcuts to enabled inside input fields.
      * @type {Array}
      */
-    var enabledInInput = ['backspace'];
+    var enabledInInput = [
+        'backspace',
+        "Meta+C",
+        "Meta+V",
+        "Meta+Alt+V",
+        "Meta+Shift+Alt+V",
+        "Meta+X",
+        "Ctrl+c",
+        "Ctrl+v",
+        "Ctrl+x",
+    ];
 
     /**
      * The default configuration if nothing
@@ -164,7 +174,7 @@ define([
                 prohibitedKeyFunc = function(event) {
                     if (!inputEnabled || !$(event.target).closest(':input').length) {
                         event.preventDefault();
-                        testRunner.trigger('prohibited-key', shortcut.label);
+                        testRunner.trigger('prohibited-key', shortcut.label, {avoidInput: true});
                     }
                 };
                 prohibitedKeyDebounce = _.debounce(prohibitedKeyFunc, config.debounceDelay, { leading : true, trailing : false});

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -142,20 +142,26 @@ define([
             var prohibitedKeyDebounce;
 
             function prevent(event) {
+                if ($(event.target).closest('textarea, input, [contenteditable]')) {
+                    return;
+                }
                 event.stopPropagation();
                 event.preventDefault();
                 testRunner.trigger('prohibited-key', event.type);
             }
 
             registerEvent(window, 'copy', prevent);
+            registerEvent(window, 'cut', prevent);
             registerEvent(window, 'paste', prevent);
 
             _.forEach(shortcuts, function(shortcut) {
-                prohibitedKeyFunc = function() {
-                    testRunner.trigger('prohibited-key', shortcut.label);
+                prohibitedKeyFunc = function(event) {
+                    if (!$(event.target).closest(':input').length) {
+                        testRunner.trigger('prohibited-key', shortcut.label);
+                    }
                 };
                 prohibitedKeyDebounce = _.debounce(prohibitedKeyFunc, config.debounceDelay, { leading : true, trailing : false});
-                shortcutHelper.add(shortcut.key, prohibitedKeyDebounce);
+                shortcutHelper.add(shortcut.key, prohibitedKeyDebounce, {avoidInput: true});
             });
 
             testRunner.on('destroy', function() {

--- a/views/js/runner/plugins/security/preventScreenshot.js
+++ b/views/js/runner/plugins/security/preventScreenshot.js
@@ -59,8 +59,10 @@ define([
     }
 
     function handleCopyEvent(event) {
-        overrideClipboard(event.clipboardData);
-        event.preventDefault();
+        if (event.clipboardData.files.length > 0) { // Image
+            overrideClipboard(event.clipboardData);
+            event.preventDefault();
+        };
     }
 
     function overrideClipboard(clipboardData) {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-343

Update plain version html to allow copy/paste when in secure mode

**How to test:**
- create delivery with textareas/inputs and with enabled security plugins
- login to ACT as a Guest or as user
- try to use clipboard in mentioned fields


