### PR TITLE
Fixed QUnit test for latency.js

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.14.1',
+    'version' => '2.14.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=31.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -299,6 +299,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.12.0');
         }
 
-        $this->skip('2.12.0', '2.14.1');
+        $this->skip('2.12.0', '2.14.2');
     }
 }

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -146,16 +146,16 @@ define([
              * @param numTry
              */
             function insistentSender(traceData, numTry = 0) {
-                if (numTry > 5) {
+                if (numTry >= 5) {
                     // stop tries
                     return;
                 }
                 testRunner.getProxy()
                   .sendVariables(traceData, true)
                   .catch(function () {
-                      setTimeout(function () {
+                      _.delay(function () {
                           insistentSender(traceData, ++numTry);
-                      }, 300);
+                      }, 250);
                   });
             }
 

--- a/views/js/test/runner/plugins/probes/latency/test.js
+++ b/views/js/test/runner/plugins/probes/latency/test.js
@@ -129,13 +129,11 @@ define([
             getProxy: function() {
                 return {
                     sendVariables: function(trace) {
-                        return new Promise(function(resolve) {
-                            var traceData = _.indexBy(probeData, function(entry) {
-                                return (entry.marker ? entry.marker + '-' : '') + entry.type + '-' + entry.id;
-                            });
-                            assert.deepEqual(trace, traceData, 'The trace data should have been provided');
-                            resolve();
+                        var traceData = _.indexBy(probeData, function(entry) {
+                            return (entry.marker ? entry.marker + '-' : '') + entry.type + '-' + entry.id;
                         });
+                        assert.deepEqual(trace, traceData, 'The trace data should have been provided');
+                        return Promise.resolve();
                     }
                 };
             },
@@ -233,9 +231,7 @@ define([
             getProxy: function() {
                 return {
                     sendVariables: function() {
-                        return new Promise(function (resolve) {
-                            resolve();
-                        });
+                        return Promise.resolve();
                     }
                 };
             },

--- a/views/js/test/runner/plugins/probes/latency/test.js
+++ b/views/js/test/runner/plugins/probes/latency/test.js
@@ -129,11 +129,12 @@ define([
             getProxy: function() {
                 return {
                     sendVariables: function(trace) {
-                        return new Promise(function() {
+                        return new Promise(function(resolve) {
                             var traceData = _.indexBy(probeData, function(entry) {
                                 return (entry.marker ? entry.marker + '-' : '') + entry.type + '-' + entry.id;
                             });
                             assert.deepEqual(trace, traceData, 'The trace data should have been provided');
+                            resolve();
                         });
                     }
                 };
@@ -232,7 +233,9 @@ define([
             getProxy: function() {
                 return {
                     sendVariables: function() {
-                        return new Promise();
+                        return new Promise(function (resolve) {
+                            resolve();
+                        });
                     }
                 };
             },


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/ACT-462
 
Broken tests for the latency.js
 
#### Steps to reproduce  (for bugs)
 - run qunit tests for the taoTestRunnerPlugins extension
  
#### How to test
 
Test commands :
 
```
cd tao/views/build
npx grunt connect:dev taotestrunnerpluginstest
```