### PR TITLE
[TCA-519] WTP-1521 - ACT: security plugin doesn't work properly for text-box, if entered text interactions have constraints

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.15.1',
+    'version' => '2.15.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -299,6 +299,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('2.12.0');
         }
 
-        $this->skip('2.12.0', '2.15.1');
+        $this->skip('2.12.0', '2.15.2');
     }
 }

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -197,15 +197,23 @@ define([
                 shortcutHelper.add(shortcut.key, prohibitedKeyDebounce, {avoidInput: true});
             });
 
-            testRunner.on('destroy', function() {
-                unregisterEvent(window, 'copy', onCopyCut);
-                unregisterEvent(window, 'cut', onCopyCut);
-                unregisterEvent(window, 'paste', onPaste);
+            testRunner
+                .on('renderitem', function () {
+                    testRunner
+                        .getAreaBroker()
+                        .getContentArea()
+                        .find('textarea, input, [contenteditable]')
+                        .attr('data-clipboard', '');
+                })
+                .on('destroy', function() {
+                    unregisterEvent(window, 'copy', onCopyCut);
+                    unregisterEvent(window, 'cut', onCopyCut);
+                    unregisterEvent(window, 'paste', onPaste);
 
-                _.forEach(shortcuts, function(shortcut) {
-                    shortcutHelper.remove(shortcut.key);
+                    _.forEach(shortcuts, function(shortcut) {
+                        shortcutHelper.remove(shortcut.key);
+                    });
                 });
-            })
         }
     });
 });


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-519
 
assign data-clipboard attribute to all inputs on item render

#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery which includes extended text interaction with some constraints
- enable security mode for the delivery
- execute the delivery as a test taker and try to copy/paste to the text interaction
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/75