### PR TITLE
Fix BSA-205 prevent ckeditor copy paste in secured mode

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.16.1',
+    'version' => '2.16.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=12.15.0',

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -182,7 +182,7 @@ define([
                         }
                     });
 
-                    var cutButton = editor.container.find('.cke_button__cut').$
+                    var cutButton = editor.container.find('.cke_button__cut').$;
 
                     if (cutButton.length) {
                         $(cutButton[0]).closest('.cke_toolgroup').remove();

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -58,9 +58,9 @@ define([
 
     /**
      * The list of shortcuts to intercept, based on current platform
-     * @type {Array}
+     * @type {Object}
      */
-    var shortcuts = [];
+    var shortcuts = {};
 
     /**
      * Identify the current platform
@@ -81,7 +81,7 @@ define([
     /** Refine the list of shortcuts to only get those that are relevant with the current platform **/
     _.forEach(allShortcuts, function(shortcut) {
         if (shortcut.platform.indexOf(platform) >= 0) {
-            shortcuts.push(shortcut);
+            shortcuts[toKeyCode(shortcut.key)] = shortcut;
         }
     });
 
@@ -125,7 +125,7 @@ define([
             switch (key) {
                 case 'Ctrl':
                 case 'Meta':
-                    keyCode += CKEDITOR.CTRL;
+                    keyCode += 1114112; // @see CKEDITOR.CTRL
                     break;
                 default:
                    if (key.length === 1) {
@@ -167,11 +167,19 @@ define([
 
                 _.forEach(editors, function (editor) {
                     editor.on('key', function (e) {
-                        _.forEach(shortcuts, function (shortcut) {
-                            if (e.data.keyCode === toKeyCode(shortcut.key)) {
-                                return e.cancel();
-                            }
-                        });
+                        var keyCode = e.data.keyCode;
+
+                        if (keyCode & CKEDITOR.SHIFT) {
+                            keyCode -= CKEDITOR.SHIFT;
+                        }
+
+                        if (keyCode & CKEDITOR.ALT) {
+                            keyCode -= CKEDITOR.ALT;
+                        }
+
+                        if (shortcuts[keyCode]) {
+                            e.cancel();
+                        }
                     });
 
                     var cutButton = editor.container.find('.cke_button__cut').$

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -173,6 +173,12 @@ define([
                             }
                         });
                     });
+
+                    var cutButton = editor.container.find('.cke_button__cut').$
+
+                    if (cutButton.length) {
+                        $(cutButton[0]).closest('.cke_toolgroup').remove();
+                    }
                 });
             }
 

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -117,6 +117,26 @@ define([
         }
     }
 
+    function toKeyCode(combination) {
+        var keys = combination.split('+');
+        var keyCode = 0;
+
+        _.forEach(keys, function (key) {
+            switch (key) {
+                case 'Ctrl':
+                case 'Meta':
+                    keyCode += CKEDITOR.CTRL;
+                    break;
+                default:
+                   if (key.length === 1) {
+                       keyCode += key.toUpperCase().charCodeAt(0);
+                   }
+            }
+        });
+
+        return keyCode;
+    }
+
     /**
      * Creates the preventCopy plugin.
      * Prevents the user to copy any content.
@@ -141,6 +161,20 @@ define([
             var prohibitedKeyFunc;
             var prohibitedKeyDebounce;
             const isIe = typeof window.clipboardData !== 'undefined';
+
+            function setUpIframeEvents(){
+                var editors = window.CKEDITOR && window.CKEDITOR.instances || [];
+
+                _.forEach(editors, function (editor) {
+                    editor.on('key', function (e) {
+                        _.forEach(shortcuts, function (shortcut) {
+                            if (e.data.keyCode === toKeyCode(shortcut.key)) {
+                                return e.cancel();
+                            }
+                        });
+                    });
+                });
+            }
 
             function replaceSelection(target, newValue) {
                 const oldValue = target.value.toString().substring(target.selectionStart, target.selectionEnd);
@@ -199,6 +233,7 @@ define([
 
             testRunner
                 .on('renderitem', function () {
+                    setUpIframeEvents();
                     testRunner
                         .getAreaBroker()
                         .getContentArea()


### PR DESCRIPTION
- [BSA-205](https://oat-sa.atlassian.net/browse/BSA-205) feat: subscribe to `key` event of `CKEditor` instances in order to catch any of the restricted shortcuts and prevent them
- [BSA-205](https://oat-sa.atlassian.net/browse/BSA-205) feat: remove `CKEditor` instances' copy/cut/paste buttons in secured delivery execution mode
- [BSA-205](https://oat-sa.atlassian.net/browse/BSA-205) chore(version): bump a fix one