### PR TITLE
Fix BSA-204: allow fake input copy

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.16.2',
+    'version' => '2.16.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=12.15.0',

--- a/views/js/runner/plugins/security/preventCopy.js
+++ b/views/js/runner/plugins/security/preventCopy.js
@@ -169,10 +169,12 @@ define([
                     editor.on('key', function (e) {
                         var keyCode = e.data.keyCode;
 
+                        // noinspection JSBitwiseOperatorUsage
                         if (keyCode & CKEDITOR.SHIFT) {
                             keyCode -= CKEDITOR.SHIFT;
                         }
 
+                        // noinspection JSBitwiseOperatorUsage
                         if (keyCode & CKEDITOR.ALT) {
                             keyCode -= CKEDITOR.ALT;
                         }
@@ -201,9 +203,15 @@ define([
                 target.focus();
             }
             function onCopyCut(event) {
-                event.preventDefault();
                 const target = $(event.target).closest('textarea, input, [contenteditable]')[0];
+
                 if (target) {
+                    const $target = $(target);
+
+                    if ($target.hasClass('allow-copy')) {
+                        return;
+                    }
+
                     const text = target.value.toString().substring(target.selectionStart, target.selectionEnd);
                     if (isIe) {
                         window.clipboardData.setData('Text', '');
@@ -213,11 +221,14 @@ define([
                     if (event.type === 'cut') {
                         replaceSelection(target, '');
                     }
-                    $(target).attr('data-clipboard', text);
+
+                    $target.attr('data-clipboard', text);
                 } else {
                     event.stopPropagation();
                     testRunner.trigger('prohibited-key', event.type);
                 }
+
+                event.preventDefault();
             }
             function onPaste(event) {
                 event.preventDefault();

--- a/views/js/runner/plugins/security/preventScreenshot.js
+++ b/views/js/runner/plugins/security/preventScreenshot.js
@@ -64,6 +64,7 @@ define([
     const focusOnFakeInput = () => {
         const input = document.createElement('input');
         input.setAttribute('value', overrideContent);
+        input.classList.add('allow-copy');
         document.body.appendChild(input);
         input.select();
         triggerCopyEvent();


### PR DESCRIPTION
- [BSA-204](https://oat-sa.atlassian.net/browse/BSA-204) fix: allow a `copy` event on a fake input, generated by `preventScreenshot` in order to successfully override clipboard contents upon a screenshot attempt
- [BSA-204](https://oat-sa.atlassian.net/browse/BSA-204) chore(version): bump a fix one