### PR TITLE
Fix/REF-116/fullscreen ipad iOS 13 detection

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Manage test runner plugins',
     'description' =>  "Manage test runner's plugins",
     'license' => 'GPL-2.0',
-    'version' => '2.16.3',
+    'version' => '2.16.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=12.15.0',

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -106,7 +106,8 @@ define([
      * Check for iOS platform
      * @type {Boolean}
      */
-    var iOS = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
+    var iOS = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform) ||
+        (navigator.userAgent.includes('Mac') && 'ontouchend' in document); // iPad on iOS 13 detection
 
     /**
      * Checks if the page has been embedded inside a frame


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/REF-116

The fullscreen mode doesn't switch on iOS, fixed detection iPad iOS 13

How to test:

1. create a delivery with security mode
2. run delivery on iPad with iOS 13
3. check fullscreen mode off