### PR TITLE
Hotfix/REF-120/check loaded item is answered

### DIFF
--- a/views/js/runner/plugins/navigation/limitBackButton.js
+++ b/views/js/runner/plugins/navigation/limitBackButton.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2020 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -26,8 +26,9 @@
 define([
     'jquery',
     'lodash',
-    'taoTests/runner/plugin'
-], function ($, _, pluginFactory) {
+    'taoTests/runner/plugin',
+    'taoQtiTest/runner/helpers/currentItem'
+], function ($, _, pluginFactory, currentItemHelper) {
     'use strict';
 
     const pluginName = 'limitBackButton';
@@ -153,6 +154,11 @@ define([
                     .on('loaditem', itemIdentifier => {
                         disableState = false;
                         currentItemIdentifier = itemIdentifier;
+                    })
+                    .before('renderitem', () => {
+                        if (currentItemHelper.isAnswered(testRunner)) {
+                            return store.setItem(currentItemIdentifier, true);
+                        }
                     })
                     .after('renderitem', () => {
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/REF-120
**Backport https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/169**

**Problem:**
When test with status 'in progress'  is run by LTI on another browser Back Button is not disabled for the answered item, because the state of the button is stored in the browser.
**Solution:** 
Check the loaded item is answered.

How to test:
- launch the delivery by LTI on one browser
- answer 2-3 items
- launch the delivery by LTI on other browsers
- back button should be disabled for answered items