### PR TITLE
fix: empty array instead of null for offline imports

### DIFF
--- a/model/offline/JsonOfflineTestImporter.php
+++ b/model/offline/JsonOfflineTestImporter.php
@@ -79,7 +79,7 @@ class JsonOfflineTestImporter implements \tao_models_classes_import_ImportHandle
      */
     public function getForm()
     {
-        return (new OfflineTestImportForm(null))->getForm();
+        return (new OfflineTestImportForm([]))->getForm();
     }
 
     /**

--- a/test/integration/model/JsonOfflineImportTest.php
+++ b/test/integration/model/JsonOfflineImportTest.php
@@ -38,9 +38,18 @@ use qtism\common\enums\Cardinality;
 use qtism\runtime\common\OutcomeVariable;
 use qtism\runtime\tests\AssessmentTestSession;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\oatbox\filesystem\FileSystemService;
+
 
 class JsonOfflineImportTest extends TaoPhpUnitTestRunner
 {
+    public function testGetForm()
+    {
+        $importer = new JsonOfflineTestImporter();
+        $importer->setServiceLocator($this->getMockServiceLocator());
+        $this->assertInstanceOf(tao_helpers_form_xhtml_Form::class, $importer->getForm());
+    }
+
     /**
      * @dataProvider importDataProvider
      *
@@ -170,17 +179,19 @@ class JsonOfflineImportTest extends TaoPhpUnitTestRunner
             'http://sample/first.rdf#i154661273822141'
         )->willReturn($serviceContext);
         $qtiCommunicationService = $this->prophesize(QtiCommunicationService::class);
-        $qtiCommunicationService->processInput($serviceContext, $this->getMockData())->willReturn(true);
+        $qtiCommunicationService->processInput($serviceContext, $this->getMockData())->willReturn([]);
 
         $uriProvider = $this->prophesize(UriProvider::class);
         $uriProvider->provide()->willReturn('http://sample/first.rdf#i1544535042650000');
+        $filesystemService = $this->createMock(FileSystemService::class);
 
         return $this->getServiceLocatorMock([
             ServiceProxy::SERVICE_ID => $prophecy,
             QtiRunnerService::SERVICE_ID => $qtiRunnerService,
             UploadService::SERVICE_ID => $upload,
             QtiCommunicationService::SERVICE_ID => $qtiCommunicationService,
-            UriProvider::SERVICE_ID => $uriProvider
+            UriProvider::SERVICE_ID => $uriProvider,
+            FileSystemService::SERVICE_ID => $filesystemService
         ]);
     }
     /**


### PR DESCRIPTION
After the last refactoring for tao-core its require to use an array
https://github.com/oat-sa/tao-core/commit/da22e9bce1f338d8305e3e3d53b96abe28e7d949#diff-457c122ca06fa703ec83d0230f80831abb9f254022e81ba59ccaf5be545f642cR80