### PR TITLE
fix: TR-1197 proceed firefox/chrome fullscreen via F11 key

### DIFF
--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -23,15 +23,13 @@ define([
     'lodash',
     'i18n',
     'taoTests/runner/plugin',
-    /* 'core/logger', // uncomment to enable fullscreen request denied logging */
     'taoQtiTest/runner/config/states',
     'css!taoTestRunnerPlugins/runner/plugins/security/css/fullscreen'
-], function (_, __, pluginFactory, /* loggerFactory, */ states) {
+], function (_, __, pluginFactory, states) {
     'use strict';
 
     var doc = document;
     var docElem = doc.documentElement;
-    /* var logger = loggerFactory('testRunnerPlugins/fullScreen'); // uncomment to enable fullscreen request denied logging */
 
     /**
      * CSS class name to adjust the full screen mode
@@ -142,7 +140,6 @@ define([
         if (docElem.requestFullscreen) {
             // HTML5 compliant browsers
             docElem.requestFullscreen().catch(function (e) {
-                /* logger.warn(e) || // uncomment to enable fullscreen request denied logging */
                 console.warn(e && e.message);
             });
         } else if (docElem.msRequestFullscreen) {

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -285,10 +285,8 @@ define([
                         disableItem();
 
                         isFullScreenAlert = true;
-                        // startWebkitF11FullScreenChangeObserver();
                         testRunner.trigger('alert.fullscreen', message, function(reason) {
                             isFullScreenAlert = false;
-                            // stopWebkitF11FullScreenChangeObserver();
 
                             if (reason === 'esc') {
                                 waitingForUser = false;

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -63,12 +63,6 @@ define([
     var changeObserverHandler;
 
     /**
-     * Flag that mirrors visibility of full screen alert
-     * @type {Boolean}
-     */
-    var isFullScreenAlert = false;
-
-    /**
      * The keyboard shortcut to active the full screen mode.
      * @type {String}
      */
@@ -292,9 +286,7 @@ define([
                         stopFullScreenChangeObserver();
                         disableItem();
 
-                        isFullScreenAlert = true;
                         testRunner.trigger('alert.fullscreen', message, function(reason) {
-                            isFullScreenAlert = false;
 
                             if (reason === 'esc') {
                                 waitingForUser = false;

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -255,8 +255,8 @@ define([
             }
 
             function handleFullScreenChange() {
-                // defer handler execution to process fullscreen state before calculate checkFullScreen()
-                _.defer(function(){
+                // delay handler execution to process fullscreen state before calculate checkFullScreen()
+                _.delay(function(){
                     isFullScreen = checkFullScreen();
                     if (isFullScreen) {
                         enterFullScreen(testRunner);
@@ -266,7 +266,7 @@ define([
                         leaveFullScreen(testRunner);
                         alertUser();
                     }
-                })
+                }, 100);
             }
             const throttledHandleResizeToFullScreenChange = _.throttle(handleFullScreenChange, 50);
             function startWebkitF11FullScreenChangeObserver() {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1197

- fullscreen warning popup no more shows after switch to fullscreen mode via F11 (webkit/mozilla)

Requires: none