### PR TITLE
Fix/tr 1197/winchrome detect fullscreen

### DIFF
--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -266,9 +266,9 @@ define([
                         leaveFullScreen(testRunner);
                         alertUser();
                     }
-                }, 100);
+                }, 75);
             }
-            const throttledHandleResizeToFullScreenChange = _.throttle(handleFullScreenChange, 50);
+            const throttledHandleResizeToFullScreenChange = _.throttle(handleFullScreenChange, 25);
             function startWebkitF11FullScreenChangeObserver() {
                 window.addEventListener('resize', throttledHandleResizeToFullScreenChange);
             }

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -123,13 +123,15 @@ define([
      * @returns {Boolean}
      */
     function checkFullScreen() {
+        const screenSizeGap = 30;
         if (fullScreenProperty in doc) {
             const isGenericFullScreen = !!doc[fullScreenProperty];
-            const isSizeFullScreen = screen.width === window.outerWidth && screen.height === window.outerHeight;
+            const isSizeFullScreen = Math.abs (screen.width - window.outerWidth) < screenSizeGap
+                && Math.abs (screen.height - window.outerHeight) < screenSizeGap;
             return isGenericFullScreen || isSizeFullScreen;
         } else {
             // when the browser does not implement the full screen API, arbitrary checks if the full screen mode is active
-            return (screen.availHeight || screen.height - 30) <= window.innerHeight;
+            return (screen.availHeight || screen.height - screenSizeGap) <= window.innerHeight;
         }
     }
 
@@ -266,9 +268,9 @@ define([
                         leaveFullScreen(testRunner);
                         alertUser();
                     }
-                }, 75);
+                }, 100);
             }
-            const throttledHandleResizeToFullScreenChange = _.throttle(handleFullScreenChange, 25);
+            const throttledHandleResizeToFullScreenChange = _.throttle(handleFullScreenChange, 50);
             function startWebkitF11FullScreenChangeObserver() {
                 window.addEventListener('resize', throttledHandleResizeToFullScreenChange);
             }

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -123,15 +123,16 @@ define([
      * @returns {Boolean}
      */
     function checkFullScreen() {
-        const screenSizeGap = 30;
+
         if (fullScreenProperty in doc) {
             const isGenericFullScreen = !!doc[fullScreenProperty];
-            const isSizeFullScreen = Math.abs (screen.width - window.outerWidth) < screenSizeGap
-                && Math.abs (screen.height - window.outerHeight) < screenSizeGap;
+            const screenSizeGap = 16;
+            const isSizeFullScreen = Math.abs (screen.width - window.outerWidth) <= screenSizeGap
+                && Math.abs (screen.height - window.outerHeight) <= screenSizeGap;
             return isGenericFullScreen || isSizeFullScreen;
         } else {
             // when the browser does not implement the full screen API, arbitrary checks if the full screen mode is active
-            return (screen.availHeight || screen.height - screenSizeGap) <= window.innerHeight;
+            return (screen.availHeight || screen.height - 30) <= window.innerHeight;
         }
     }
 


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TR-1197

**Changes:**
- investigated that  screen size and window size sometimes is not equal for fullscreen mode 
- avoid screen/window size difference for fullscreen mode for some os/browser cases (windows10/chrome) 

**How to check:**
- run delivery with enabled "security restrictions" option and wait for fullscreen popup appears
- press F11 (Ctrl+⌘+F for MacOS)
- ensure popup disappears

**Requires:**
 - none