### PR TITLE
[Incident] TR-1550 - Browser not exiting full screen mode on assessment exit  - Safari only

### DIFF
--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -166,7 +166,7 @@ define([
         } else if (doc.mozCancelFullScreen) { /* Firefox */
             doc.mozCancelFullScreen();
         } else if (doc.webkitExitFullscreen) { /* Chrome, Safari and Opera */
-            doc.webkitExitFullscreen();
+            doc.webkitCancelFullscreen();
         } else if (doc.msExitFullscreen) { /* IE/Edge */
             doc.msExitFullscreen();
         }

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -328,7 +328,7 @@ define([
                 });
 
                 testRunner
-                    .on('exit', function() {
+                    .on('finish leave exit', function() {
                         doc.removeEventListener(fullScreenEventName, handleFullScreenChange);
                         stopWebkitF11FullScreenChangeObserver();
                         leaveFullScreen(testRunner);

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -165,7 +165,7 @@ define([
             doc.exitFullscreen();
         } else if (doc.mozCancelFullScreen) { /* Firefox */
             doc.mozCancelFullScreen();
-        } else if (doc.webkitExitFullscreen) { /* Chrome, Safari and Opera */
+        } else if (doc.webkitCancelFullscreen) { /* Chrome, Safari and Opera */
             doc.webkitCancelFullscreen();
         } else if (doc.msExitFullscreen) { /* IE/Edge */
             doc.msExitFullscreen();

--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -165,8 +165,8 @@ define([
             doc.exitFullscreen();
         } else if (doc.mozCancelFullScreen) { /* Firefox */
             doc.mozCancelFullScreen();
-        } else if (doc.webkitCancelFullscreen) { /* Chrome, Safari and Opera */
-            doc.webkitCancelFullscreen();
+        } else if (doc.webkitExitFullscreen) { /* Chrome, Safari and Opera */
+            doc.webkitExitFullscreen();
         } else if (doc.msExitFullscreen) { /* IE/Edge */
             doc.msExitFullscreen();
         }


### PR DESCRIPTION
**Related to:** [TR-1550](https://oat-sa.atlassian.net/browse/TR-1550)

**Description**

Cancel fullscreen when exiting/pausing/finishing a test (currently failing only in Safari)

**Changes**

- Added `finish leave` to `.on('finish leave exit', handler)`

**How to test**

- Run an assessment on a safari browser
- Exit that assessment (complete, or pause (discontinue is sometimes also impacted))
- You are left in full screen mode. 