### PR TITLE
hotfix/TR-1550/exit-fullscreen-safari

### DIFF
--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -328,7 +328,7 @@ define([
                 });
 
                 testRunner
-                    .on('exit', function() {
+                    .on('finish leave exit', function() {
                         doc.removeEventListener(fullScreenEventName, handleFullScreenChange);
                         stopWebkitF11FullScreenChangeObserver();
                         leaveFullScreen(testRunner);


### PR DESCRIPTION
**Related to**: [TR-1550](https://oat-sa.atlassian.net/browse/TR-1550)

**Description**

Cancel fullscreen when exiting/pausing/finishing a test (currently failing only in Safari)

**Changes**

- Added finish leave to .on('finish leave exit', handler)

**How to test**

- Run an assessment on a safari browser
- Exit that assessment (complete, or pause (discontinue is sometimes also impacted))
- You are left in full screen mode.