### PR TITLE
Fix/TR-2399/fullscreen dialog do not close on escape

### DIFF
--- a/views/js/runner/plugins/security/fullScreen.js
+++ b/views/js/runner/plugins/security/fullScreen.js
@@ -288,7 +288,7 @@ define([
 
                         testRunner.trigger('alert.fullscreen', message, function(reason) {
 
-                            if (reason === 'esc') {
+                            if (reason === 'escape') {
                                 waitingForUser = false;
                                 return alertUser();
                             }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-2399

- [ ] ??? update version of this extension  in https://github.com/oat-sa/tao-enterprise-nfer-enot/

Fullscreen dialog should *not* be closed with 'Esc' key. 
Dialog component is shown by test-runner: https://github.com/oat-sa/tao-test-runner-qti-fe/blob/master/src/plugins/content/dialog/dialog.js#L216
Underlying 'modal' component sends `'escape'` as a `reason`, not `'esc'`:  https://github.com/oat-sa/tao-core-ui-fe/blob/develop/src/modal.js#L181
Why not use `disableEscape` 'modal' option?  Because at the moment `tao-core-ui\src\dialog\alert.js` used here doesn't pass it through.
Why not actually close dialog and go into fullscreen mode on 'Esc' key? Because we'll get "_API can only be initiated by a user gesture_" error.



How to test:
- ~~run unit tests:~~ there is no test for this plugin?
- add `taoTestRunnerPlugins` and `nferEnot` extension (I installed https://github.com/oat-sa/tao-enterprise-nfer-enot with `taoDockerize` and enabled this extension using admin ui "_Settings->Extensions_")
- enable `fullscreen` plugin if it's not enabled yet (find `fullScreen` entry in `\config\taoTests\test_runner_plugin_registry.conf.php`, set `active = true` for it, then from container `d exec -it tao-nferenot-phpfpm sh` ran `php tao/scripts/taoUpdate.php`)
- run any delivery and check steps from the ticket. When creating delivery ensure there's `Security plugins` checkbox and it's checked 