### PR TITLE
chore: update methods to lodash 4 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.24.6",
+        "oat-sa/tao-core": ">=54.0.0",
         "oat-sa/extension-tao-delivery": ">=15.0.0",
         "oat-sa/extension-tao-delivery-rdf": ">=14.0.0",
         "oat-sa/extension-tao-testqti": ">=41.0.0",

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -288,7 +288,7 @@ define([
             if (_.isEmpty(name) || !_.isString(name)) {
                 throw new TypeError('A capture processor have a valid name');
             }
-            captureProcessors = _.omit(captureProcessors, name);
+            captureProcessors = _.omitBy(captureProcessors, name);
             return this;
         }
     };

--- a/views/js/runner/plugins/probes/latency.js
+++ b/views/js/runner/plugins/probes/latency.js
@@ -288,7 +288,7 @@ define([
             if (_.isEmpty(name) || !_.isString(name)) {
                 throw new TypeError('A capture processor have a valid name');
             }
-            captureProcessors = _.omitBy(captureProcessors, name);
+            captureProcessors = _.omit(captureProcessors, name);
             return this;
         }
     };

--- a/views/js/runner/plugins/security/sectionPause.js
+++ b/views/js/runner/plugins/security/sectionPause.js
@@ -64,7 +64,7 @@ define([
                 return new Promise(function(resolve, reject){
                     if(context.options.sectionPause &&
                         previousSection && section && section.id !== previousSection.id &&
-                        item && _.contains(item.categories, sectionPauseCategory) ) {
+                        item && _.includes(item.categories, sectionPauseCategory) ) {
 
                         testRunner
                             // when the pause has been taken into account, the runner will end the session

--- a/views/js/test/runner/plugins/probes/latency/test.js
+++ b/views/js/test/runner/plugins/probes/latency/test.js
@@ -129,7 +129,7 @@ define([
             getProxy: function() {
                 return {
                     sendVariables: function(trace) {
-                        var traceData = _.indexBy(probeData, function(entry) {
+                        var traceData = _.keyBy(probeData, function(entry) {
                             return (entry.marker ? entry.marker + '-' : '') + entry.type + '-' + entry.id;
                         });
                         assert.deepEqual(trace, traceData, 'The trace data should have been provided');


### PR DESCRIPTION
Related: https://oat-sa.atlassian.net/browse/ADF-1579
Update lodash methods to version 4.
Documentation: https://github.com/lodash/lodash/wiki/Migrating